### PR TITLE
Update run.windows.py

### DIFF
--- a/release-tools/ami_ids
+++ b/release-tools/ami_ids
@@ -1,2 +1,3 @@
 us-west-2=ami-76cbaa46
 us-east-1=ami-cdae9ca4
+eu-west-1=ami-aeb242d9


### PR DESCRIPTION
Can someone review these changes and merge this pull request?
The updates to the run.windows.py script are as follows:
- Ask user if they want to use a key pair and if they don't then use a default one
  - SSH access into these VMs is definitely needed, but we don't necessarily need to ask users about the key pair if this is too confusing for some StochSS users. What do others think?
- Add eu-west-1 as a supported region.
- Confirm that user still wants to use saved values in config file
  - This is just for the region, instance ID and key pair. Makes it easy to try the script again if you mistype one of these without having to edit/delete the .ec2-config file.
