### PR TITLE
Fixed issue where error in executing improper mass action reactions not reported back to user

### DIFF
--- a/app/handlers/simulation.py
+++ b/app/handlers/simulation.py
@@ -794,7 +794,12 @@ class SimulatePage(BaseHandler):
             if not modelDb:
                 return {'status':False,'msg':'Failed to retrive the model to simulate.'}
 
-            model = modelDb.createStochKitModel()
+            try:
+                model = modelDb.createStochKitModel()
+            except Exception as e:
+                traceback.print_exc()
+                return {"status" : False, "msg" : "Error: {0}".format(e)}
+                
 
             # Execute as concentration or population?
             execType = params['execType']


### PR DESCRIPTION
So the behavior I observed is:

1. The model editor allows mass action reaction products and species to have unconstrained numbers of reactants
2. Simulating the model would fail without showing an error (it would just sit at 'running') in the case the stoichiometry of reactants was greater than 2

The patch fixes 2. The other issue (harder to fix) added here: https://github.com/StochSS/stochss/issues/326