### PR TITLE
Br custom propensity

### DIFF
--- a/src/models/reaction.js
+++ b/src/models/reaction.js
@@ -10,7 +10,9 @@ module.exports = State.extend({
     name:  'string',
     annotation: 'string',
     // True indicates a custom mass action equation
-    massaction: 'boolean'
+    massaction: 'boolean',
+    type: 'string',
+    propensity: 'string'
   },
   children: {
     rate: Parameter,
@@ -26,44 +28,5 @@ module.exports = State.extend({
       default: true
     }
   },
-  derived: {
-    type: {
-      // The reaction type is not persisted to the database,
-      // so we infer it based on the structure of reactants and products
-      deps: ['massaction', 'reactants', 'products'],
-      fn: function () {
-        var numReactants = this.reactants.length;
-        var numProducts = this.products.length;
-        if (!this.massaction) {
-          if (!numReactants) {
-            return 'creation';
-          }
-          if (!numProducts) {
-            return 'destruction';
-          }
-          if (numReactants === 1 && numProducts === 1) {
-            var reactant = this.reactants.at(0);
-            if (reactant.ratio === 1) {
-              return 'change';
-            } else { // ratio is 2
-              return 'dimerization';
-            }
-          }
-          if (numReactants === 2 && numProducts === 1) {
-            return 'merge';
-          }
-          if (numReactants === 1 && numProducts === 2) {
-            return 'split';
-          }
-          if (numReactants === 2 && numProducts === 2) {
-            return 'four';
-          }
-        } else {
-          // TODO handle case for custom mass action
-          // Use defaults for new reactions (see reaction-types.js)
-          // otherwise use what we got back from database
-        }
-      }
-    }
-  }
+
 });

--- a/src/styles/bootstrap.css
+++ b/src/styles/bootstrap.css
@@ -205,6 +205,12 @@ svg {
   vertical-align: middle;
 }
 
+span {
+  padding-right: 0.35rem;
+  padding-left: 0.35rem;
+  font-size: 1rem;
+}
+
 table {
   border-collapse: collapse;
 }

--- a/src/templates/includes/editCustomStoichSpecie.pug
+++ b/src/templates/includes/editCustomStoichSpecie.pug
@@ -1,0 +1,10 @@
+div
+  button.btn.btn-outline-secondary(class='btn-sm', data-hook='increment') +
+  span(data-hook="ratio")
+  button.btn.btn-outline-secondary(class='btn-sm', data-hook='decrement') -
+  label.select
+    span(data-hook="label")
+    select(data-hook="select-stoich-specie")
+      span.message.message-below.message-error(data-hook="message-container")
+        p(data-hook="message-text")
+  button.btn.btn-outline-secondary(class='btn-sm', data-hook='remove') X

--- a/src/templates/includes/modelListing.pug
+++ b/src/templates/includes/modelListing.pug
@@ -7,4 +7,17 @@ tr
       each version_tag in this.model.get("version_tags")
         option(value=version_tag)= version_tag
   td(data-hook="public")
-  td: button.btn.btn-outline-secondary(data-hook="remove") X
+  td
+    a.btn.btn-outline-secondary(data-toggle='modal', href='#delete-modal', data-hook='confirm-delete') X
+
+#delete-modal(class='modal fade')
+  div(class='modal-dialog')
+    div(class='modal-content')
+      div(class='modal-header')
+        h4(class='modal-title') header
+        button(class='close', data-dismiss='modal') X
+      div(class='modal-body')
+        h4 body
+      div(class='modal-footer')
+        button
+          btn.btn-danger(data-dismiss='modal') No

--- a/src/templates/includes/reactionDetails.pug
+++ b/src/templates/includes/reactionDetails.pug
@@ -1,35 +1,15 @@
 div.reaction-details(data-hook="reaction-details-container")
 
-  //- block comment
-    div.col-md-12
-      label(for="select-reaction-type")
-        | Reaction Type:
-      select#select-reaction-type(data-hook="select-reaction-type")
-        option(data-hook="creation") O -> A
-        option(data-hook="destruction") A -> O
-        option(data-hook="change") A -> B
-        option(data-hook="dimerization") A+A -> B
-        option(data-hook="merge") A+B -> C
-        option(data-hook="split") A -> B+C
-        option(data-hook="four") A+B -> C+D
-        option(data-hook="custom-massaction") Custom mass action
-        option(data-hook="custom-propensity") Custom propensity
-
+  
   div.col-md-12(data-hook="select-reaction-type")
 
   div.col-md-12(data-hook="select-rate-parameter")
 
-  //- comment block
-    div.col-md-12 
-      label(for="select-rate-parameter")
-        | Rate parameter:
-      select#select-rate-parameter(data-hook="select-rate-parameter")
-        each param in this.model.parameters.models
-          option(value=param.name)= param.name
-
   div.row(data-hook="stoich-species-container")
     div.col-md-6(data-hook="reactants-editor")
       h5 Reactants
+      //div
     div.col-md-6(data-hook="products-editor")
       h5 Products
+      //div
 

--- a/src/views/edit-custom-stoich-specie.js
+++ b/src/views/edit-custom-stoich-specie.js
@@ -1,0 +1,57 @@
+var SelectView = require('ampersand-select-view');
+
+var template = require('../templates/includes/editCustomStoichSpecie.pug');
+
+module.exports = SelectView.extend({
+  // SelectView expects a string template, so pre-render it
+  template: template(),
+  bindings: {
+    'model.ratio' : {
+      hook: 'ratio'
+    }
+  },
+  events: {
+    'change select' : 'selectChangeHandler',
+    'click [data-hook=increment]' : 'handleIncrement',
+    'click [data-hook=decrement]' : 'handleDecrement',
+    'click [data-hook=remove]' : 'deleteSpecie'
+  },
+  initialize: function () {
+    SelectView.prototype.initialize.apply(this, arguments);
+    this.value = this.model.specie || null;
+  },
+  selectChangeHandler: function (e) {
+    var species = this.getSpeciesCollection();
+    var reactions = this.getReactionsCollection();
+    var specie = species.filter(function (m) {
+      return m.name === e.target.selectedOptions.item(0).text;
+    })[0];
+    this.model.specie = specie;
+    this.value = specie;
+    // Trigger change on reactions to update inUse
+    reactions.trigger("change");
+  },
+  getReactionsCollection: function () {
+    return this.model.collection.parent.collection;
+  },
+  getSpeciesCollection: function () {
+    // TODO there are a growing number of gnarly upward refs like this one;
+    // there's probably a better way get this this via events, functions on parents, etc
+    // Originally we had set reaction.species as a convenience reference,
+    // perhaps that is the solution to return to.
+    //
+    //     this.(StoichSpecie).(StoichSpecies).(Reaction).(Reactions).(Version).species
+    return this.model.collection.parent.collection.parent.species;
+  },
+  handleIncrement: function () {
+    this.model.ratio++;
+  },
+  handleDecrement: function () {
+    this.model.ratio > 1 ? this.model.ratio-- : this.model.ratio = 1;
+  },
+  deleteSpecie: function () {
+    this.model.collection.remove(this.model);
+    //TODO:  Remove the specie from the collection of reactants or products
+  }
+});
+

--- a/src/views/edit-stoich-specie.js
+++ b/src/views/edit-stoich-specie.js
@@ -40,5 +40,6 @@ module.exports = SelectView.extend({
     //     this.(StoichSpecie).(StoichSpecies).(Reaction).(Reactions).(Version).species
     return this.model.collection.parent.collection.parent.species;
   }
+  
 });
 

--- a/src/views/model-listing.js
+++ b/src/views/model-listing.js
@@ -1,5 +1,6 @@
 var View = require('ampersand-view');
 var _ = require('underscore');
+var $ = require('jquery');
 
 var template = require('../templates/includes/modelListing.pug');
 
@@ -10,7 +11,7 @@ module.exports = View.extend({
   },
   events: {
     "change [data-hook='version-select']": "selectVersion",
-    "click [data-hook=remove]" : "clickRemoveHandler"
+    "click [data-hook=confirm-delete]" : "clickRemoveHandler"
   },
   bindings: {
     'model.name' : '[data-hook~=name]',
@@ -40,6 +41,9 @@ module.exports = View.extend({
     }
   },
   clickRemoveHandler: function (e) {
+    
+    //$('#delete-modal').modal('show');
+    //alert("You confirmed the deletion of this Model!");
     this.removeModel();
   },
   selectVersion: function (e) {
@@ -48,8 +52,6 @@ module.exports = View.extend({
   removeModel: function () {
     var model = this.model;
     if (!model.isNew()){
-      this.remove();
-      this.model.collection.remove(this.model);
       model.destroy({
         success: function () {
           alert("The model was successfully deleted.");


### PR DESCRIPTION
Reaction types are no longer derived.  edit-custom-stoich-specie.js and editCustomStoichSpecie.pug were added to support the custom propensity and custom mass action reaction types.  Reactant and product ratios can be adjusted buttons.  Reactants and products can be removed with buttons.  The rate parameter is stored using a propensity prop but is set up to be stored as a child.