### PR TITLE
Fix 500 errors for singleuser containers

### DIFF
--- a/stochss/server/.env
+++ b/stochss/server/.env
@@ -12,8 +12,6 @@ STOCHSS_DB=./stochssdb.sqlite
 
 STOCHSS_DB_CONNECT=sqlite:///./stochssdb.sqlite
 
-DOCKER_STOCHSS_CONTAINER_NAME=stochss-jupyterhub
-
 DOCKER_NETWORK_NAME=stochss-net
 
 DOCKER_NOTEBOOK_IMAGE=stochss-singleuser

--- a/stochss/server/Makefile
+++ b/stochss/server/Makefile
@@ -44,14 +44,14 @@ build: check-files network
 	docker build -t $(DOCKER_STOCHSS_IMAGE):latest .
 
 run: check-files network
-	docker run -it \
+	docker run -it --rm \
+		--name jupyterhub \
 		-p 443:443 \
 		--env-file .env \
 		--env-file ./secrets/oauth.env \
 		-v $(PWD):/srv/jupyterhub \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		--network $(DOCKER_NETWORK_NAME) \
-		-h $(DOCKER_STOCHSS_CONTAINER_NAME) \
 		$(DOCKER_STOCHSS_IMAGE):latest
 
 .PHONY: network volumes check-files pull notebook_image build

--- a/stochss/server/jupyterhub_config.py
+++ b/stochss/server/jupyterhub_config.py
@@ -125,7 +125,7 @@ with open(os.path.join(pwd, 'userlist')) as f:
 #    - simple: jupyterhub.spawner.SimpleLocalProcessSpawner
 c.JupyterHub.spawner_class = 'dockerspawner.DockerSpawner'
 
-c.DockerSpawner.container_image = os.environ['DOCKER_NOTEBOOK_IMAGE']
+c.DockerSpawner.container_image = os.environ['LOCAL_NOTEBOOK_IMAGE']
 # JupyterHub requires a single-user instance of the Notebook server, so we
 # default to using the `start-singleuser.sh` script included in the
 # jupyter/docker-stacks *-notebook images as the Docker run command when
@@ -164,7 +164,7 @@ c.DockerSpawner.debug = True
 #  
 #  See `hub_connect_ip` for cases where the bind and connect address should
 #  differ, or `hub_bind_url` for setting the full bind URL.
-c.JupyterHub.hub_ip = os.environ['DOCKER_STOCHSS_CONTAINER_NAME']
+c.JupyterHub.hub_ip =  'jupyterhub'
 
 ## The internal port for the Hub process.
 #  


### PR DESCRIPTION
A configuration error was causing notebook containers to not be able to communicate with the hub. Adding the `--name` parameters to the `docker run` command in `Makefile` causes the hostname to be set correctly within the docker network so notebook containers can correctly identify the internal hub ip.