### PR TITLE
Br solver bug fixes

### DIFF
--- a/stochss/client/src/models/hybrid-tau-settings.js
+++ b/stochss/client/src/models/hybrid-tau-settings.js
@@ -8,11 +8,11 @@ module.exports = State.extend({
     },
     tauTolerance: {
       type: 'number',
-      default: 0.3
+      default: 0.03
     },
     switchingTolerance: {
       type: 'number',
-      default: 0.3
+      default: 0.03
     }
   }
 });

--- a/stochss/client/src/models/simulation-settings.js
+++ b/stochss/client/src/models/simulation-settings.js
@@ -10,11 +10,11 @@ module.exports = State.extend({
     },
     endSim: {
       type: 'number',
-      default: 100
+      default: 20
     },
     timeStep: {
       type: 'number',
-      default: 1.0
+      default: 0.05
     },
   },
   children: {

--- a/stochss/client/src/models/tau-leaping-settings.js
+++ b/stochss/client/src/models/tau-leaping-settings.js
@@ -8,7 +8,7 @@ module.exports = State.extend({
     },
     tauTolerance: {
       type: 'number',
-      default: 0.3
+      default: 0.03
     }
   }
 })

--- a/stochss/client/src/templates/includes/deterministicSettings.pug
+++ b/stochss/client/src/templates/includes/deterministicSettings.pug
@@ -1,8 +1,10 @@
 div#deterministic-settings.card.card-body
 
-  h5
-    button.btn.btn-link(data-toggle='collapse', data-target='#advanced-settings', data-hook='advanced-settings-button')
-      |Advanced Settings
+  div.row
+
+    h5 Advanced Settings
+  
+    button.btn.btn-outline-collapse(data-toggle='collapse', data-target='#advanced-settings', data-hook='advanced-settings-button') +
 
   div(id='advanced-settings', class='collapse', data-hook='advanced-settings')
     table.table
@@ -19,3 +21,5 @@ div#deterministic-settings.card.card-body
 
         tr
           td(colspan="2"): div(data-hook="absolute-tolerance-container")
+
+    p.text-danger Currently the relative tolerance and the absolute tolerance are not being used by the Basic ODE solver.  This is a work in progress by the GillesPy2 team.

--- a/stochss/client/src/templates/includes/editRateRule.pug
+++ b/stochss/client/src/templates/includes/editRateRule.pug
@@ -1,5 +1,5 @@
 div.row
 
-  div.col-md-3(data-hook="rate-rule-name")
+  div.col-md-6(data-hook="rate-rule-name")
 
-  div(data-hook="rate-rule")
+  div.col-md-6(data-hook="rate-rule")

--- a/stochss/client/src/templates/includes/editRateRule.pug
+++ b/stochss/client/src/templates/includes/editRateRule.pug
@@ -1,5 +1,5 @@
 div.row
 
-  div(data-hook="rate-rule-name")
+  div.col-md-3(data-hook="rate-rule-name")
 
   div(data-hook="rate-rule")

--- a/stochss/client/src/templates/includes/editSpecieMode.pug
+++ b/stochss/client/src/templates/includes/editSpecieMode.pug
@@ -1,4 +1,4 @@
-div.col-md-12
+div
   label.select
     span(data-hook="label")
     select(data-hook="select-specie-mode")

--- a/stochss/client/src/templates/includes/hybridTauSettings.pug
+++ b/stochss/client/src/templates/includes/hybridTauSettings.pug
@@ -24,7 +24,7 @@ div#hybrid-tau-settings.card.card-body
 
     thread
       tr
-        th(scope="col") Species Mode
+        th.w-25(scope="col") Species Mode
         th(scope="col") Rate Rules
 
       tr

--- a/stochss/client/src/templates/includes/meshEditor.pug
+++ b/stochss/client/src/templates/includes/meshEditor.pug
@@ -4,7 +4,7 @@ div#mesh-editor.card.card-body
 
     h3 Mesh Editor
 
-    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-mesh", data-hook="collapse") +
+    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-mesh", data-hook="collapse") -
 
   div.collapse(class="show", id="collapse-mesh")
 

--- a/stochss/client/src/templates/includes/parametersEditor.pug
+++ b/stochss/client/src/templates/includes/parametersEditor.pug
@@ -4,7 +4,7 @@ div#parameters-editor.card.card-body
 
     h3 Parameters Editor
 
-    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-parameters", data-hook="collapse") +
+    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-parameters", data-hook="collapse") -
 
   div.collapse(class="show", id="collapse-parameters")
 

--- a/stochss/client/src/templates/includes/reactionsEditor.pug
+++ b/stochss/client/src/templates/includes/reactionsEditor.pug
@@ -4,7 +4,7 @@ div#reactions-editor.card.card-body
 
     h3 Reactions
 
-    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-reaction", data-hook="collapse") +
+    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-reaction", data-hook="collapse") -
 
   div.collapse(class="show", id="collapse-reaction")
 

--- a/stochss/client/src/templates/includes/simSettings.pug
+++ b/stochss/client/src/templates/includes/simSettings.pug
@@ -4,7 +4,7 @@ div#sim-settings.card.card-body
 
     h3 Simulation Settings
 
-    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-settings", data-hook="collapse") +
+    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-settings", data-hook="collapse") -
 
   div.collapse(class="show", id="collapse-settings")
 

--- a/stochss/client/src/templates/includes/spatialSpeciesEditor.pug
+++ b/stochss/client/src/templates/includes/spatialSpeciesEditor.pug
@@ -4,7 +4,7 @@ div#species-editor.card.card-body
 
     h3 Species Editor
 
-    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-species", data-hook="collapse") +
+    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-species", data-hook="collapse") -
 
   div.collapse(class="show", id="collapse-species")
 

--- a/stochss/client/src/templates/includes/speciesEditor.pug
+++ b/stochss/client/src/templates/includes/speciesEditor.pug
@@ -4,7 +4,7 @@ div#species-editor.card.card-body
 
     h3 Species Editor
 
-    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-species", data-hook="collapse") +
+    button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#collapse-species", data-hook="collapse") -
 
   div.collapse(class="show", id="collapse-species")
 

--- a/stochss/client/src/templates/includes/stochasticSettings.pug
+++ b/stochss/client/src/templates/includes/stochasticSettings.pug
@@ -7,9 +7,11 @@ div#stochastic-settings.card.card-body
       tr
         td: div(data-hook="realizations-container")
 
-  h5
-    button.btn.btn-link(data-toggle='collapse', data-target='#advanced-settings', data-hook='advanced-settings-button')
-      |Advanced Settings
+  div.row
+
+    h6 Advanced Settings
+    
+    button.btn.btn-outline-collapse(data-toggle='collapse', data-target='#advanced-settings', data-hook='advanced-settings-button') +
 
   div(id='advanced-settings', class='collapse', data-hook='advanced-settings')
     table.table

--- a/stochss/client/src/templates/includes/tauLeapingSettings.pug
+++ b/stochss/client/src/templates/includes/tauLeapingSettings.pug
@@ -10,7 +10,7 @@ div#tau-leaping-settings.card.card-body
 
     thread
       tr
-        th(scope="col") Relative Tau Tolerance
+        th(scope="col") Tau Tolerance
 
       tr
         td: div(data-hook="tau-tolerance-container")

--- a/stochss/client/src/views/deterministic-settings.js
+++ b/stochss/client/src/views/deterministic-settings.js
@@ -24,8 +24,10 @@ module.exports = View.extend({
   },
   render: function () {
     View.prototype.render.apply(this);
-    if(this.model.isAdvancedSettingsOpen)
+    if(this.model.isAdvancedSettingsOpen) {
       $(this.queryByHook('advanced-settings')).collapse();
+      $(this.queryByHook('advanced-settings-button')).text('-');
+    }
   },
   update: function (e) {
   },
@@ -62,7 +64,13 @@ module.exports = View.extend({
     }
   },
   toggleAdvancedSettings: function (e) {
-    this.model.isAdvancedSettingsOpen ? this.setIsAdvancedSettingsOpen(false) : this.setIsAdvancedSettingsOpen(true);
+    if(this.model.isAdvancedSettingsOpen) {
+      this.setIsAdvancedSettingsOpen(false)
+      $(this.queryByHook('advanced-settings-button')).text('+');
+    } else {
+      this.setIsAdvancedSettingsOpen(true);
+      $(this.queryByHook('advanced-settings-button')).text('-');
+    }
   },
   setIsAdvancedSettingsOpen: function (value) {
     this.model.isAdvancedSettingsOpen = value;

--- a/stochss/client/src/views/hybrid-tau-settings.js
+++ b/stochss/client/src/views/hybrid-tau-settings.js
@@ -37,7 +37,6 @@ module.exports = View.extend({
         eagerValidate: true,
         idAttribute: 'mode',
         options: ['continuous', 'discrete', 'dynamic'],
-        unselectedText: 'Select a mode',
         value: ''
       }
     };

--- a/stochss/client/src/views/parameters-editor.js
+++ b/stochss/client/src/views/parameters-editor.js
@@ -19,7 +19,7 @@ module.exports = View.extend({
     this.renderCollection(this.collection, EditParameterView, this.queryByHook('parameter-list'));
   },
   addParameter: function () {
-    var defaultName = 'k' + this.collection.length;
+    var defaultName = 'K' + (this.collection.length + 1);
     this.collection.add({
       name: defaultName,
       value: 0

--- a/stochss/client/src/views/reactant-product.js
+++ b/stochss/client/src/views/reactant-product.js
@@ -37,8 +37,7 @@ module.exports = View.extend({
         // Set idAttribute to name. Models may not be saved yet so id is unreliable (so is cid).
         // Use name since it *should be* unique.
         idAttribute: 'name',
-        options: self.species,
-        unselectedText: self.unselectedText
+        options: self.species
       }
     };
     var type = self.reactionType;

--- a/stochss/client/src/views/reaction-details.js
+++ b/stochss/client/src/views/reaction-details.js
@@ -56,7 +56,6 @@ module.exports = View.extend({
       idAttribute: 'cid',
       textAttribute: 'name',
       eagerValidate: true,
-      unselectedText: 'Pick a parameter',
       options: this.model.collection.parent.parameters,
       // For new reactions (with no rate.name) just use the first parameter in the Parameters collection
       // Else fetch the right Parameter from Parameters based on existing rate

--- a/stochss/client/src/views/reaction-listing.js
+++ b/stochss/client/src/views/reaction-listing.js
@@ -33,6 +33,7 @@ module.exports = View.extend({
   },
   removeReaction: function (e) {
     this.model.collection.remove(this.model);
+    this.parent.collection.trigger("change");
   }
 
 });

--- a/stochss/client/src/views/reactions-editor.js
+++ b/stochss/client/src/views/reactions-editor.js
@@ -112,7 +112,7 @@ module.exports = View.extend({
     this.detailsViewSwitcher.set(reaction.detailsView);
   },
   getDefaultReactionName: function () {
-    return 'R' + this.collection.length;
+    return 'R' + (this.collection.length + 1);
   },
   getStoichArgsForReactionType: function(type) {
     var args = ReactionTypes[type];

--- a/stochss/client/src/views/stochastic-settings.js
+++ b/stochss/client/src/views/stochastic-settings.js
@@ -46,8 +46,10 @@ module.exports = View.extend({
       el: this.algorithmSettingsContainer,
     });
     this.setStochasticAlgorithm(this.model.algorithm);
-    if(this.model.isAdvancedSettingsOpen)
+    if(this.model.isAdvancedSettingsOpen){
       $(this.queryByHook('advanced-settings')).collapse();
+      $(this.queryByHook('advanced-settings-button')).text('-');
+    }
   },
   subviews: {
     inputRealizations: {
@@ -86,7 +88,13 @@ module.exports = View.extend({
     }
   },
   toggleAdvancedSettings: function (e) {
-    this.model.isAdvancedSettingsOpen ? this.openCloseAdvancedSettings(false) : this.openCloseAdvancedSettings(false);
+    if(this.model.isAdvancedSettingsOpen) {
+      this.openCloseAdvancedSettings(false)
+      $(this.queryByHook('advanced-settings-button')).text('+');
+    } else {
+      this.openCloseAdvancedSettings(true);
+      $(this.queryByHook('advanced-settings-button')).text('-');
+    }
   },
   openCloseAdvancedSettings: function (value) {
     this.model.isAdvancedSettingsOpen = value;

--- a/stochss/server/orm.py
+++ b/stochss/server/orm.py
@@ -80,7 +80,7 @@ class SimSettings(Base):
     id = Column(Integer, primary_key=True)
     is_stochastic = Column(Boolean)
     endSim = Column(Integer)
-    timeStep = Column(Integer)
+    timeStep = Column(Float)
     realizations = Column(Integer)
     algorithm = Column(String)
     ssaSeed = Column(Integer)
@@ -203,7 +203,7 @@ class Specie(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String)
-    value = Column(Float)
+    value = Column(Integer)
     mode = Column(String)
     diffusionCoeff = Column(Float)
     subdomains = Column(String)

--- a/stochss/server/orm.py
+++ b/stochss/server/orm.py
@@ -51,7 +51,7 @@ class ModelVersion(Base):
     model = relationship("Model", back_populates="versions")
 
     # Relationships (one-to-one)
-    simSettings = relationship("SimSettings", uselist=False, back_populates="version", cascade='all, delete')
+    simSettings = relationship("SimSettings", uselist=False, back_populates="version", cascade='all, delete, delete-orphan')
 
     # Relationships (one-to-many)
     reactions = relationship("Reaction", back_populates="version", cascade='all, delete, delete-orphan')

--- a/stochss/server/run_models.py
+++ b/stochss/server/run_models.py
@@ -105,35 +105,44 @@ class RunModelAPIHandler(BaseHandler):
 
     def ssaSolver(self, model, data):
         solver = get_best_ssa_solver()
+        seed = data['stochasticSettings']['ssaSettings']['seed']
+        if(seed == -1):
+            seed = None
         return solver.run(
             model = model,
             t = data['endSim'],
             number_of_trajectories = data['stochasticSettings']['realizations'],
             increment = data['timeStep'],
-            seed = data['stochasticSettings']['ssaSettings']['seed']
+            seed = seed
         )
 
 
     def basicTauLeapingSolver(self, model, data):
         solver = BasicTauLeapingSolver()
+        seed = data['stochasticSettings']['tauLeapingSettings']['seed']
+        if(seed == -1):
+            seed = None
         return solver.run(
             model = model,
             t = data['endSim'],
             number_of_trajectories = data['stochasticSettings']['realizations'],
             increment = data['timeStep'],
-            seed = data['stochasticSettings']['tauLeapingSettings']['seed'],
+            seed = seed,
             tau_tol = data['stochasticSettings']['tauLeapingSettings']['tauTolerance']
         )
 
 
     def basicTauHybridSolver(self, model, data):
         solver = BasicTauHybridSolver()
+        seed = data['stochasticSettings']['hybridTauSettings']['seed']
+        if(seed == -1):
+            seed = None
         return solver.run(
             model = model,
             t = data['endSim'],
             number_of_trajectories = data['stochasticSettings']['realizations'],
             increment = data['timeStep'],
-            seed = data['stochasticSettings']['hybridTauSettings']['seed'],
+            seed = seed,
             hybrid_tol = data['stochasticSettings']['hybridTauSettings']['switchingTolerance'],
             tau_tol = data['stochasticSettings']['hybridTauSettings']['tauTolerance']
         )

--- a/stochss/server/run_models.py
+++ b/stochss/server/run_models.py
@@ -34,20 +34,32 @@ class _Model(Model):
 
 class ModelFactory():
 
+    log = logging.getLogger()
+    log.setLevel(10)
+
     def __init__(self, data):
         name = data['name']
         timeStep = (data['simSettings']['timeStep'])
         endSim = data['simSettings']['endSim']
+        self.log.debug("Species: ")
         self.species = list(map(lambda s: self.build_specie(s), data['species']))
+        self.log.debug("Parameters: ")
         self.parameters = list(map(lambda p: self.build_parameter(p), data['parameters']))
         self.reactions = list(map(lambda r: self.build_reaction(r, self.parameters), data['reactions']))
         self.model = _Model(name, self.species, self.parameters, self.reactions, endSim, timeStep)
 
     def build_specie(self, args):
-        return Species(name=args['name'], initial_value=int(args['nonspatialSpecies']['value']), mode=args['nonspatialSpecies']['mode'])
+        name = args['name']
+        value = args['nonspatialSpecies']['value']
+        mode = args['nonspatialSpecies']['mode']
+        self.log.debug("name: {0}, value: {1}, mode: {2}".format(name, value, mode))
+        return Species(name=name, initial_value=value, mode=mode)
 
     def build_parameter(self, args):
-        return Parameter(name=args['name'], expression=args['value'])
+        name = args['name']
+        value = args['value']
+        self.log.debug("name: {0}, expression: {1}".format(name, value))
+        return Parameter(name=name, expression=value)
 
     def build_reaction(self, args, parameters):
         R = Reaction(


### PR DESCRIPTION
Fixed the long error of death.  Fixed the random seed error.  Fixed the naming for parameters and reactions to make them consistent with species.  Fixed default sim settings to match the defaults of the solvers.  Fixed a bug that was causing the advanced settings to close when switching from stochastic to deterministic.  Refactored the advanced settings collapse button to be consistent with the editor collapse buttons.  Refactored the formatting of the species mode and rate rules container.