### PR TITLE
to-notebook bug fixes

### DIFF
--- a/client/pages/model-browser.js
+++ b/client/pages/model-browser.js
@@ -233,6 +233,7 @@ let FileBrowser = PageView.extend({
             "label" : "Convert to Notebook",
             "action" : function (data) {
               var endpoint = path.join("/stochss/api/models/to-notebook", o.original._path)
+<<<<<<< Updated upstream
               xhr({ uri: endpoint },
                     function (err, response, body) {
                 var node = $('#models-jstree').jstree().get_node(o.parent)
@@ -247,6 +248,16 @@ let FileBrowser = PageView.extend({
                   },
                 );
               });
+=======
+              xhr({ uri: endpoint }, function (err, response, body) {
+                if(o.parent === "#") {
+                  $('#models-jstree').jstree().refresh()
+                }else{
+                  var node = $('#models-jstree').jstree().get_node(o.parent)
+                  $('#models-jstree').jstree().refresh_node(node);
+                }
+              })
+>>>>>>> Stashed changes
             }
           },
           "Start Job" : {

--- a/handlers/models.py
+++ b/handlers/models.py
@@ -110,7 +110,7 @@ class ModelToNotebookHandler(BaseHandler):
         user = self.current_user.name
         container = client.containers.list(filters={'name': 'jupyter-{0}'.format(user)})[0]
         file_path = '/home/jovyan{0}'.format(path)
-        fcode, _fslist = container.exec_run(cmd='convert_to_notebook.py {0}'.format(path))
+        fcode, _fslist = container.exec_run(cmd='convert_to_notebook.py "{0}"'.format(path))
         fslist = _fslist.decode()
         self.write(fslist)
 


### PR DESCRIPTION
Fixed a bug that was preventing files with spaces in to name from being converted.  Fixed a bug that was prevents the top level of the tree from refreshing after the convertion.