### PR TITLE
Context menu for file type 'other'

### DIFF
--- a/client/pages/model-browser.js
+++ b/client/pages/model-browser.js
@@ -250,6 +250,15 @@ let FileBrowser = PageView.extend({
               $('#models-jstree').jstree().refresh_node(o);
             }
           },
+          "Rename" : {
+            "separator_before" : false,
+            "separator_after" : false,
+            "_disabled" : false,
+            "label" : "Rename",
+            "action" : function (data) {
+              self.renameNode(o);
+            }
+          },
           "create_model" : {
             "label" : "Create Model",
             "separator_before" : false,
@@ -309,6 +318,15 @@ let FileBrowser = PageView.extend({
               window.location.href = path.join("/hub/stochss/models/edit", o.original._path);
             }
           },
+          "Rename" : {
+            "separator_before" : false,
+            "separator_after" : false,
+            "_disabled" : false,
+            "label" : "Rename",
+            "action" : function (data) {
+              self.renameNode(o);
+            }
+          },
           "Duplicate" : {
             "separator_before" : false,
             "separator_after" : false,
@@ -334,15 +352,6 @@ let FileBrowser = PageView.extend({
             "label" : "Convert to Notebook",
             "action" : function (data) {
 
-            }
-          },
-          "Rename" : {
-            "separator_before" : false,
-            "separator_after" : false,
-            "_disabled" : false,
-            "label" : "Rename",
-            "action" : function (data) {
-              self.renameNode(o);
             }
           },
           "Create New Job" : {
@@ -375,6 +384,15 @@ let FileBrowser = PageView.extend({
             "label" : "Edit",
             "action" : function (data) {
               window.location.href = path.join("/hub/stochss/models/edit", o.original._path);
+            }
+          },
+          "Rename" : {
+            "separator_before" : false,
+            "separator_after" : false,
+            "_disabled" : false,
+            "label" : "Rename",
+            "action" : function (data) {
+              self.renameNode(o);
             }
           },
           "Duplicate" : {
@@ -416,15 +434,6 @@ let FileBrowser = PageView.extend({
                   },
                 );
               });
-            }
-          },
-          "Rename" : {
-            "separator_before" : false,
-            "separator_after" : false,
-            "_disabled" : false,
-            "label" : "Rename",
-            "action" : function (data) {
-              self.renameNode(o);
             }
           },
           "Create New Job" : {
@@ -552,6 +561,15 @@ let FileBrowser = PageView.extend({
               self.duplicateFile(o)
             }
           },
+          "Rename" : {
+            "separator_before" : false,
+            "separator_after" : false,
+            "_disabled" : false,
+            "label" : "Rename",
+            "action" : function (data) {
+              self.renameNode(o);
+            }
+          },
           "Delete" : {
             "label" : "Delete",
             "_disabled" : false,
@@ -561,6 +579,19 @@ let FileBrowser = PageView.extend({
               self.deleteFile(o);
             }
           },
+        }
+      }
+      else {
+        return {
+          "Open File" : {
+            "separator_before" : false,
+            "separator_after" : true,
+            "_disabled" : false,
+            "_class" : "font-weight-bolder",
+            "label" : "Open File",
+            "action" : function (data) {
+            }
+          },
           "Rename" : {
             "separator_before" : false,
             "separator_after" : false,
@@ -568,6 +599,24 @@ let FileBrowser = PageView.extend({
             "label" : "Rename",
             "action" : function (data) {
               self.renameNode(o);
+            }
+          },
+          "Duplicate" : {
+            "separator_before" : false,
+            "separator_after" : false,
+            "_disabled" : false,
+            "label" : "Duplicate",
+            "action" : function (data) {
+              self.duplicateFile(o)
+            }
+          },
+          "Delete" : {
+            "label" : "Delete",
+            "_disabled" : false,
+            "separator_before" : false,
+            "separator_after" : false,
+            "action" : function (data) {
+              self.deleteFile(o);
             }
           },
         }

--- a/singleuser/scripts/duplicate.py
+++ b/singleuser/scripts/duplicate.py
@@ -112,6 +112,6 @@ if __name__ == "__main__":
     full_path = path.join(user_dir, args.file_path)
     file = full_path.split('/').pop()
     dir_path = full_path.split(file)[0]
-    unique_file_name = get_unqiue_file_name(_path, dir_path)
+    unique_file_name = get_unqiue_file_name(full_path, dir_path)
     message = duplicate(full_path, unique_file_name)
     print(message)

--- a/singleuser/scripts/rename.py
+++ b/singleuser/scripts/rename.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import shutil
 import sys
 import json
 import argparse
@@ -49,7 +50,7 @@ def rename(old_path, new_name, dir_path):
         Path to the parent directory of the target file.
     '''
     new_path, changed = get_unique_file_name(new_name, dir_path)
-    os.rename(old_path, new_path)
+    shutil.move(old_path, new_path)
     
     if changed:
         message = "A file already exists with that name, {0} was renamed to {1} in order to prevent a file from being overwriten.".format(old_path.split('/').pop(), new_name)
@@ -78,8 +79,12 @@ def get_parsed_args():
 if __name__ == "__main__":
     args = get_parsed_args()
     old_path = os.path.join(user_dir, args.path)
-    old_name = old_path.split('/').pop()
-    dir_path = old_path.split(old_name)[0]
     new_name = args.new_name
+    old_name = old_path.split('/').pop()
+    if os.path.isdir(old_path):
+        old_path += "/"
+        new_name += "/"
+        old_name += "/"
+    dir_path = old_path.split(old_name)[0]
     resp = rename(old_path, new_name, dir_path)
     print(resp)


### PR DESCRIPTION
Added the context menu for other type.  Refactored the rename script to use shutil.move instead of os.rename to allow directories to be renamed.  Added the rename menu option to the folder context menu.