### PR TITLE
Fix broken notebooks

### DIFF
--- a/singleuser/page.html
+++ b/singleuser/page.html
@@ -16,9 +16,9 @@
     {% endblock %}
     <link rel="stylesheet" href="{{ base_url }}custom/custom.css" type="text/css" />
     <script src="{{static_url("components/es6-promise/promise.min.js")}}" type="text/javascript" charset="utf-8"></script>
-    <script src="{{static_url('components/react/react.production.min.js')}}" type="text/javascript"></script>
-    <script src="{{static_url('components/react/react-dom.production.min.js')}}" type="text/javascript"></script>
-    <script src="{{static_url('components/create-react-class/index.js')}}" type="text/javascript"></script>
+    <script src="{{static_url('components/preact/index.js')}}" type="text/javascript"></script>
+    <script src="{{static_url('components/proptypes/index.js')}}" type="text/javascript"></script>
+    <script src="{{static_url('components/preact-compat/index.js')}}" type="text/javascript"></script>
     <script src="{{static_url('components/requirejs/require.js') }}" type="text/javascript" charset="utf-8"></script>
     <script>
       require.config({
@@ -37,9 +37,9 @@
             jquery: 'components/jquery/jquery.min',
             json: 'components/requirejs-plugins/src/json',
             text: 'components/requirejs-text/text',
-            bootstrap: 'components/bootstrap/dist/js/bootstrap.min',
+            bootstrap: 'components/bootstrap/js/bootstrap.min',
             bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
-            'jquery-ui': 'components/jquery-ui/jquery-ui.min',
+            'jquery-ui': 'components/jquery-ui/ui/minified/jquery-ui.min',
             moment: 'components/moment/min/moment-with-locales',
             codemirror: 'components/codemirror',
             termjs: 'components/xterm.js/xterm',
@@ -77,6 +77,7 @@
           },
           waitSeconds: 30,
       });
+
       require.config({
           map: {
               '*':{
@@ -84,6 +85,7 @@
               }
           }
       });
+
       // error-catching custom.js shim.
       define("custom", function (require, exports, module) {
           try {
@@ -95,6 +97,7 @@
               return {};
           }
       })
+
     document.nbjs_translations = {{ nbjs_translations|safe }};
     document.documentElement.lang = navigator.language.toLowerCase();
     </script>
@@ -119,11 +122,12 @@ dir="ltr">
   </div>
 </noscript>
 
-<div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
+<div id="header">
   <div id="header-container" class="container">
-  <div id="ipython_notebook" class="nav">
+  <div id="ipython_notebook" class="nav navbar-brand"><a href="{{default_url}}
+    {%- if logged_in and token -%}?token={{token}}{%- endif -%}" title='{% trans %}dashboard{% endtrans %}'>
     <a target="_blank" class="nav navbar-brand" style="font-size: 23px" href="/stochss" title='StochSS'>StochSS</a>
-  </div>
+  </a></div>
 
   {% block headercontainer %}
   {% endblock %}


### PR DESCRIPTION
Update the lightly edited page.html template that replaces the jupyter-notebook page.html template (we change the title to StochSS). The existing template file was based on an outdated file that was made for an older version of jupyter-notebook, which was causing notebooks to fail to load.