### PR TITLE
Logo link change and gillespy2 version increase

### DIFF
--- a/client/templates/body.pug
+++ b/client/templates/body.pug
@@ -1,6 +1,6 @@
 body
   nav.navbar.navbar-expand-lg.p-1.navbar-light.bg-light.fixed-top
-    a.navbar-brand(href="/stochss")
+    a.navbar-brand(href="/hub/spawn")
       img(style="height: 38px;margin-left: -1.2em;" src="static/stochss-logo.png")
 
     div#navbar.collapse.navbar-collapse.justify-content-end

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-libsbml==5.18.0
-gillespy2==1.3.0
+gillespy2==1.3.3
 vtk
 pygmsh==5.0.2
 meshio==2.3.10


### PR DESCRIPTION
Changes the StochSS logo link to /hub/spawn instead of the
StochSS home page. Also increase the gillespy2 version to 1.3.3