### PR TITLE
Fixed typo in page title, Simlation -> Simulation

### DIFF
--- a/client/templates/pages/home.pug
+++ b/client/templates/pages/home.pug
@@ -2,7 +2,7 @@ html
 
   head
     meta(charset="utf-8")
-    title StochSS: Stochastic Simlation Service
+    title StochSS: Stochastic Simulation Service
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
     meta(name="description", content="")
     meta(name="author", content="")


### PR DESCRIPTION
Page title in home.pug (shown on mouseover on the browser tab) reads:
StochSS: Stochastic Simlation Service

Changed to:
StochSS: Stochastic Simulation Service