### PR TITLE
Removed 'Simlation' typo... again?

### DIFF
--- a/client/templates/head.pug
+++ b/client/templates/head.pug
@@ -1,6 +1,6 @@
 head
   meta(charset="utf-8")
-  title StochSS: Stochastic Simlation Service
+  title StochSS: Stochastic Simulation Service
   meta(name="viewport", content="width=device-width, initial-scale=1.0")
   meta(name="description", content="")
   meta(name="author", content="")

--- a/client/templates/pages/home.pug
+++ b/client/templates/pages/home.pug
@@ -2,7 +2,7 @@ html
 
   head
     meta(charset="utf-8")
-    title StochSS: Stochastic Simlation Service
+    title StochSS: Stochastic Simulation Service
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
     meta(name="description", content="")
     meta(name="author", content="")


### PR DESCRIPTION
The typo in the page title that I corrected in an earlier pull request ("Stochastic Simlation Service") has grown back-- with two heads instead of one.

grep -r . Simlation reveals no other incidence of the string in the codebase, so hopefully this will slay the hydra.