### PR TITLE
Hotfixes

### DIFF
--- a/client/modals.js
+++ b/client/modals.js
@@ -385,6 +385,18 @@ module.exports = {
 
         return templates.select(modalID, selectID, title, label, options)
     },
+    selectSpeciesHTML : (species) => {
+      let modalID = "speciesSelectModal";
+      let selectID = "speciesSelectList";
+      let title = "Preview Variable Selection";
+      let label = "Select a variable to preview: ";
+      var options = species.map(function (name) {
+        return `<option value="${name}">${name}</option>`
+      });
+      options = options.join(" ");
+
+      return templates.select(modalID, selectID, title, label, options)
+    },
     projectExportSuccessHtml : (fileType, message) => {
       let modalID = "projectExportSuccessModal"
       let title = `Successfully Exported the ${fileType}`

--- a/client/models/domain-types.js
+++ b/client/models/domain-types.js
@@ -24,8 +24,10 @@ var Collection = require('ampersand-collection');
 module.exports = Collection.extend({
   model: Type,
   indexes: ['typeID'],
-  addType: function (vol, mass, nu, fixed) {
-    let id = this.parent.getDefaultTypeID();
+  addType: function (vol, mass, nu, fixed, id=null) {
+    if(!id) {
+      id = this.parent.getDefaultTypeID();
+    }
     let name = String(id);
     var type = new Type({
         fixed: fixed,

--- a/client/models/model.js
+++ b/client/models/model.js
@@ -110,7 +110,7 @@ module.exports = Model.extend({
     //TODO: implement auto save
   },
   //called when save button is clicked
-  saveModel: function () {
+  saveModel: function (cb=null) {
     var self = this;
     this.species.map(function (specie) {
       self.species.trigger('update-species', specie.compID, specie, false, false);
@@ -118,6 +118,10 @@ module.exports = Model.extend({
     this.parameters.map(function (parameter) {
       self.parameters.trigger('update-parameters', parameter.compID, parameter);
     });
-    this.save();
+    if(cb) {
+      this.save({success: cb});
+    }else{
+      this.save()
+    }
   },
 });

--- a/client/pages/domain-editor.js
+++ b/client/pages/domain-editor.js
@@ -439,15 +439,20 @@ let DomainEditor = PageView.extend({
     this.domain.types.get(index, "typeID").name = newName;
     this.renderEditParticle();
     this.renderNewParticle();
+    this.renderTypeSelectView();
+    this.renderCreate3DDomain();
     this.plot.data[index].name = newName;
     this.updatePlot();
   },
   renderCreate3DDomain: function () {
-    let create3DDomainView = new Create3DDomainView({
+    if(this.create3DDomainView) {
+      this.create3DDomainView.remove()
+    }
+    this.create3DDomainView = new Create3DDomainView({
       parent: this,
       model: this.domain
     });
-    this.registerRenderSubview(create3DDomainView, "add-3d-domain");
+    this.registerRenderSubview(this.create3DDomainView, "add-3d-domain");
   },
   renderDomainLimitations: function () {
     let xLimMinView = new InputView({parent: this, required: true,
@@ -692,7 +697,10 @@ let DomainEditor = PageView.extend({
     this.registerRenderSubview(this.typesLocationSelectView, "types-file-location-select")
   },
   renderTypeSelectView: function () {
-    var typeView = new SelectView({
+    if(this.typeView) {
+      this.typeView.remove()
+    }
+    this.typeView = new SelectView({
       label: 'Type:  ',
       name: 'type',
       required: true,
@@ -702,7 +710,7 @@ let DomainEditor = PageView.extend({
       options: this.domain.types,
       value: this.domain.types.get(0, "typeID")
     });
-    this.registerRenderSubview(typeView, "mesh-type-select")
+    this.registerRenderSubview(this.typeView, "mesh-type-select")
   },
   saveDomain: function (name=null) {
     let domain = this.domain.toJSON();

--- a/client/pages/domain-editor.js
+++ b/client/pages/domain-editor.js
@@ -455,30 +455,38 @@ let DomainEditor = PageView.extend({
     this.registerRenderSubview(this.create3DDomainView, "add-3d-domain");
   },
   renderDomainLimitations: function () {
-    let xLimMinView = new InputView({parent: this, required: true,
+    if(this.xLimMinView) {
+      this.xLimMinView.remove();
+      this.yLimMinView.remove();
+      this.zLimMinView.remove();
+      this.xLimMaxView.remove();
+      this.yLimMaxView.remove();
+      this.zLimMaxView.remove();
+    }
+    this.xLimMinView = new InputView({parent: this, required: true,
                                      name: 'x-lim-min', valueType: 'number',
                                      value: this.domain.x_lim[0] || 0});
-    this.registerRenderSubview(xLimMinView, "x_lim-min");
-    let yLimMinView = new InputView({parent: this, required: true,
+    this.registerRenderSubview(this.xLimMinView, "x_lim-min");
+    this.yLimMinView = new InputView({parent: this, required: true,
                                      name: 'y-lim-min', valueType: 'number',
                                      value: this.domain.y_lim[0] || 0});
-    this.registerRenderSubview(yLimMinView, "y_lim-min");
-    let zLimMinView = new InputView({parent: this, required: true,
+    this.registerRenderSubview(this.yLimMinView, "y_lim-min");
+    this.zLimMinView = new InputView({parent: this, required: true,
                                      name: 'z-lim-min', valueType: 'number',
                                      value: this.domain.z_lim[0] || 0});
-    this.registerRenderSubview(zLimMinView, "z_lim-min");
-    let xLimMaxView = new InputView({parent: this, required: true,
+    this.registerRenderSubview(this.zLimMinView, "z_lim-min");
+    this.xLimMaxView = new InputView({parent: this, required: true,
                                      name: 'x-lim-max', valueType: 'number',
                                      value: this.domain.x_lim[1] || 0});
-    this.registerRenderSubview(xLimMaxView, "x_lim-max");
-    let yLimMaxView = new InputView({parent: this, required: true,
+    this.registerRenderSubview(this.xLimMaxView, "x_lim-max");
+    this.yLimMaxView = new InputView({parent: this, required: true,
                                      name: 'y-lim-max', valueType: 'number',
                                      value: this.domain.y_lim[1] || 0});
-    this.registerRenderSubview(yLimMaxView, "y_lim-max");
-    let zLimMaxView = new InputView({parent: this, required: true,
+    this.registerRenderSubview(this.yLimMaxView, "y_lim-max");
+    this.zLimMaxView = new InputView({parent: this, required: true,
                                      name: 'z-lim-max', valueType: 'number',
                                      value: this.domain.z_lim[1] || 0});
-    this.registerRenderSubview(zLimMaxView, "z_lim-max");
+    this.registerRenderSubview(this.zLimMaxView, "z_lim-max");
   },
   renderDomainProperties: function () {
     let densityView = new InputView({parent: this, required: true,

--- a/client/pages/domain-editor.js
+++ b/client/pages/domain-editor.js
@@ -287,7 +287,7 @@ let DomainEditor = PageView.extend({
       let domainType = self.domain.types.get(type, "typeID");
       if(!domainType) {
         self.domain.types.addType(defaultType.volume, defaultType.mass,
-                                  defaultType.nu, defaultType.fixed);
+                                  defaultType.nu, defaultType.fixed, type);
         self.addType(String(type));
       }
     });

--- a/client/pages/domain-editor.js
+++ b/client/pages/domain-editor.js
@@ -116,6 +116,9 @@ let DomainEditor = PageView.extend({
           self.domain.z_lim[1] = resp.limits.z_lim[1]
         }
         self.renderDomainLimitations();
+        $('html, body').animate({
+            scrollTop: $("#domain-plot").offset().top
+        }, 20);
       }
     }
     req.send(formData)

--- a/client/pages/domain-editor.js
+++ b/client/pages/domain-editor.js
@@ -142,6 +142,7 @@ let DomainEditor = PageView.extend({
     if(this.model) {
       this.model.domain = this.domain;
       this.model.saveModel();
+      window.history.back();
     }
   },
   handleSaveToFile: function () {

--- a/client/pages/file-browser.js
+++ b/client/pages/file-browser.js
@@ -459,7 +459,9 @@ let FileBrowser = PageView.extend({
         }
         var notebookPath = path.join(app.getBasePath(), "notebooks", body.FilePath)
         self.selectNode(node, body.File)
-        window.open(notebookPath, '_blank')
+        console.log(notebookPath)
+        window.open(notebookPath)
+        console.log("Opened new window")
       }
     });
   },
@@ -1007,7 +1009,7 @@ let FileBrowser = PageView.extend({
         },
         "New Workflow" : {
           "label" : "New Workflow",
-          "_disabled" : (nodeType === "spatial") ? true : false,
+          "_disabled" : false,
           "separator_before" : false,
           "separator_after" : false,
           "action" : function (data) {
@@ -1034,10 +1036,11 @@ let FileBrowser = PageView.extend({
             },
             "Convert to Notebook" : {
               "label" : "Convert to Notebook",
-              "_disabled" : true,
+              "_disabled" : false,
               "separator_before" : false,
               "separator_after" : false,
               "action" : function (data) {
+                self.toNotebook(o, "model")
               }
             }
           }

--- a/client/pages/model-editor.js
+++ b/client/pages/model-editor.js
@@ -34,6 +34,7 @@ var InitialConditionsEditorView = require('../views/initial-conditions-editor');
 var InitialConditionsViewer = require('../views/initial-conditions-viewer');
 var ParametersEditorView = require('../views/parameters-editor');
 var ParameterViewer = require('../views/parameters-viewer');
+var ParticleViewer = require('../views/view-particle');
 var ReactionsEditorView = require('../views/reactions-editor');
 var ReactionsViewer = require('../views/reactions-viewer');
 var EventsEditorView = require('../views/events-editor');
@@ -60,6 +61,7 @@ let ModelEditor = PageView.extend({
     'click [data-hook=collapse-me-advanced-section]' : 'changeCollapseButtonText',
     'click [data-hook=project-breadcrumb-link]' : 'handleProjectBreadcrumbClick',
     'click [data-hook=toggle-preview-plot]' : 'togglePreviewPlot',
+    'click [data-hook=toggle-preview-domain]' : 'toggleDomainPlot',
     'click [data-hook=download-png]' : 'clickDownloadPNGButton',
     'click [data-hook=collapse-system-volume]' : 'changeCollapseButtonText'
   },
@@ -190,6 +192,18 @@ let ModelEditor = PageView.extend({
       updateInUse(rule.variable);
     });
   },
+  renderParticleViewer: function (particle=null) {
+    if(this.particleViewer) {
+      this.particleViewer.remove();
+    }
+    if(particle){
+      $(this.queryByHook("me-select-particle")).css("display", "none")
+      this.particleViewer = new ParticleViewer({
+        model: particle
+      });
+      this.registerRenderSubview(this.particleViewer, "me-particle-viewer")
+    }
+  },
   renderSubviews: function () {
     this.modelSettings = new ModelSettingsView({
       parent: this,
@@ -208,6 +222,8 @@ let ModelEditor = PageView.extend({
       $(this.queryByHook("spatial-beta-message")).css("display", "block");
       this.renderDomainViewer();
       this.renderInitialConditions();
+      $(this.queryByHook("toggle-preview-domain")).css("display", "inline-block");
+      this.openDomainPlot();
     }else {
       this.renderEventsView();
       this.renderRulesView();
@@ -373,10 +389,36 @@ let ModelEditor = PageView.extend({
     button.innerText = "Show Preview"
   },
   openPlot: function () {
+    if($(this.queryByHook("domain-plot-viewer-container")).css("display") !== "none") {
+      this.closeDomainPlot()
+    }
     let runContainer = this.queryByHook("model-run-container")
     let button = this.queryByHook("toggle-preview-plot")
     runContainer.style.display = "block"
     button.innerText = "Hide Preview"
+  },
+  toggleDomainPlot: function (e) {
+    let action = e.target.innerText
+    if(action === "Hide Domain") {
+      this.closeDomainPlot();
+    }else{
+      this.openDomainPlot();
+    }
+  },
+  openDomainPlot: function () {
+    if($(this.queryByHook("model-run-container")).css("display") !== "none") {
+      this.closePlot();
+    }
+    let domainView = this.queryByHook("domain-plot-viewer-container")
+    let button = this.queryByHook("toggle-preview-domain")
+    domainView.style.display = "block"
+    button.innerText = "Hide Domain"
+  },
+  closeDomainPlot: function () {
+    let domainView = this.queryByHook("domain-plot-viewer-container")
+    let button = this.queryByHook("toggle-preview-domain")
+    domainView.style.display = "none"
+    button.innerText = "Show Domain"
   },
   clickDownloadPNGButton: function (e) {
     let pngButton = $('div[data-hook=preview-plot-container] a[data-title*="Download plot as a png"]')[0]

--- a/client/pages/model-editor.js
+++ b/client/pages/model-editor.js
@@ -201,11 +201,11 @@ let ModelEditor = PageView.extend({
     this.renderSpeciesView();
     this.renderParametersView();
     this.renderReactionsView();
-    this.renderSystemVolumeView();
     this.registerRenderSubview(this.modelSettings, 'model-settings-container');
     this.registerRenderSubview(this.modelStateButtons, 'model-state-buttons-container');
     if(this.model.is_spatial) {
-      $(this.queryByHook("spatial-beta-message")).css("display", "block")
+      $(this.queryByHook("model-editor-advanced-container")).css("display", "none");
+      $(this.queryByHook("spatial-beta-message")).css("display", "block");
       this.renderDomainViewer();
       this.renderInitialConditions();
     }else {
@@ -217,6 +217,7 @@ let ModelEditor = PageView.extend({
         });
         this.registerRenderSubview(sbmlComponentView, 'sbml-component-container');
       }
+      this.renderSystemVolumeView();
     }
     $(document).ready(function () {
       $('[data-toggle="tooltip"]').tooltip();

--- a/client/pages/model-editor.js
+++ b/client/pages/model-editor.js
@@ -44,6 +44,7 @@ var RulesViewer = require('../views/rules-viewer');
 var SBMLComponentView = require('../views/sbml-component-editor');
 var ModelSettingsView = require('../views/model-settings');
 var ModelStateButtonsView = require('../views/model-state-buttons');
+var QuickviewDomainTypes = require('../views/quickview-domain-types');
 //models
 var Model = require('../models/model');
 var Domain = require('../models/domain');
@@ -196,12 +197,23 @@ let ModelEditor = PageView.extend({
     if(this.particleViewer) {
       this.particleViewer.remove();
     }
+    if(this.typeQuickViewer) {
+      this.typeQuickViewer.remove();
+    }
     if(particle){
       $(this.queryByHook("me-select-particle")).css("display", "none")
       this.particleViewer = new ParticleViewer({
         model: particle
       });
       this.registerRenderSubview(this.particleViewer, "me-particle-viewer")
+    }else{
+      $(this.queryByHook("me-select-particle")).css("display", "block")
+      this.typeQuickViewer = this.renderCollection(
+        this.domainViewer.model.types,
+        QuickviewDomainTypes,
+        this.queryByHook("me-types-quick-view")
+      );
+      console.log(this.domainViewer.model.types.models)
     }
   },
   renderSubviews: function () {

--- a/client/pages/workflow-selection.js
+++ b/client/pages/workflow-selection.js
@@ -35,6 +35,7 @@ let workflowSelection = PageView.extend({
   template: template,
   events: {
     "click [data-hook=ensemble-simulation]" : "notebookWorkflow",
+    "click [data-hook=spatial-simulation]" : "notebookWorkflow",
     "click [data-hook=oned-parameter-sweep]" : "notebookWorkflow",
     "click [data-hook=twod-parameter-sweep]" : "notebookWorkflow",
     "click [data-hook=sciope-model-exploration]" : "notebookWorkflow",
@@ -101,6 +102,7 @@ let workflowSelection = PageView.extend({
       $(this.queryByHook('stochss-es')).prop('disabled', true)
       $(this.queryByHook('stochss-ps')).prop('disabled', true)
       $(this.queryByHook('ensemble-simulation')).prop('disabled', true)
+      $(this.queryByHook('spatial-simulation')).prop('disabled', true)
       $(this.queryByHook('model-inference')).prop('disabled', true)
       $(this.queryByHook('oned-parameter-sweep')).prop('disabled', true)
       $(this.queryByHook('twod-parameter-sweep')).prop('disabled', true)
@@ -110,6 +112,14 @@ let workflowSelection = PageView.extend({
         $(this.queryByHook('invalid-model-message')).html('Errors were detected in you model <a href="'+endpoint+'">click here to fix your model<a/>')
       }
       $(this.queryByHook('invalid-model-message')).css('display', 'block')
+    }else if(this.model.is_spatial){
+      $(this.queryByHook('stochss-es')).prop('disabled', true)
+      $(this.queryByHook('stochss-ps')).prop('disabled', true)
+      $(this.queryByHook('ensemble-simulation')).prop('disabled', true)
+      $(this.queryByHook('model-inference')).prop('disabled', true)
+      $(this.queryByHook('oned-parameter-sweep')).prop('disabled', true)
+      $(this.queryByHook('twod-parameter-sweep')).prop('disabled', true)
+      $(this.queryByHook('sciope-model-exploration')).prop('disabled', true)
     }else if(this.model.parameters.length < 1){
       $(this.queryByHook('oned-parameter-sweep')).prop('disabled', true)
       $(this.queryByHook('twod-parameter-sweep')).prop('disabled', true)
@@ -133,7 +143,7 @@ let workflowSelection = PageView.extend({
   },
   toNotebook: function (type) {
     let queryString = "?type="+type+"&path="+this.modelDir+"&parentPath="+this.parentPath
-    var endpoint = path.join(app.getApiPath(), "/workflow/notebook")+queryString
+    var endpoint = path.join(app.getApiPath(), "workflow/notebook")+queryString
     xhr({uri:endpoint, json:true}, function (err, response, body) {
       if(response.statusCode < 400){
         var notebookPath = path.join(app.getBasePath(), "notebooks", body.FilePath)

--- a/client/styles/styles.css
+++ b/client/styles/styles.css
@@ -630,3 +630,8 @@ span.checkbox {
 .tab {
   padding-right: 1rem;
 }
+
+.particle-view {
+  word-break: break-word !important;
+  overflow-wrap: break-word !important;
+}

--- a/client/templates/includes/domainViewer.pug
+++ b/client/templates/includes/domainViewer.pug
@@ -94,29 +94,10 @@ div#domain-viewer.card.card-body
             th(scope="col") Number of Particles
             th(scope="col") Mass
             th(scope="col") Volume
-            th(scope="col") nu
+            th(scope="col") Viscosity
             th(scope="col") Fixed
 
         tbody(data-hook="domain-types-list")
-
-    div
-
-      h4 Particles
-
-      hr
-
-      div.row
-
-        div.col-md-9
-
-          div(data-hook="domain-plot")
-
-        div.col-md-3
-
-          div(data-hook="particle-viewer")
-
-          div.text-info(data-hook="select-particle")
-            | Click on a particle to view its properties.
 
     hr
 

--- a/client/templates/includes/edit3DDomain.pug
+++ b/client/templates/includes/edit3DDomain.pug
@@ -60,7 +60,7 @@ div
         tr
           th(scope="col") Mass
           th(scope="col") Volume
-          th(scope="col") Nu
+          th(scope="col") Viscosity
           th(scope="col") Fixed
 
       tbody

--- a/client/templates/includes/edit3DDomain.pug
+++ b/client/templates/includes/edit3DDomain.pug
@@ -84,4 +84,20 @@ div
           td: div(data-hook="domain-y-trans")
           td: div(data-hook="domain-z-trans")
 
-  button.btn.btn-outline-primary(data-hook="build-domain") Build Domain
+  div.inline
+
+    button.btn.btn-outline-primary(data-hook="build-domain") Build Domain
+
+  div.mdl-edit-btn.saving-status.inline(data-hook="cd-in-progress")
+
+    div.spinner-grow.mr-2
+
+    span(data-hook="cd-action-in-progress")
+
+  div.mdl-edit-btn.saved-status.inline(data-hook="cd-complete")
+
+    span(data-hook="cd-action-complete")
+
+  div.mdl-edit-btn.save-error-status(data-hook="cd-error")
+
+    span(data-hook="cd-action-error")

--- a/client/templates/includes/editDomainType.pug
+++ b/client/templates/includes/editDomainType.pug
@@ -7,7 +7,7 @@ tr
   td
     div="mass: " + this.model.mass
     div="vol: " + this.model.volume
-    div="nu: " + this.model.nu
+    div="viscosity: " + this.model.nu
     div="fixed: " + this.model.fixed
 
   td: button.btn.btn-outline-secondary.box-shadow(data-type=this.model.typeID data-hook='edit-defaults-btn') Edit Defaults

--- a/client/templates/includes/editModelView.pug
+++ b/client/templates/includes/editModelView.pug
@@ -27,7 +27,7 @@ div
 
         div.inline: h5="Notes: "
 
-        div.inline: button.btn.btn-outline-collapse(data-toggle="collapse" data-target="#annotation-text"+this.model.name.replace(/ /g,"") data-hook="collapse-annotation-text") -
+        div.inline: button.btn.btn-outline-collapse(data-toggle="collapse" data-target="#annotation-text"+this.model.name.replace(/ /g,"") data-hook="collapse-annotation-text") +
 
     div.collapse.col-md-10.inline(id="annotation-text"+this.model.name.replace(/ /g,""))
 

--- a/client/templates/includes/editParticle.pug
+++ b/client/templates/includes/editParticle.pug
@@ -42,12 +42,22 @@ div.card.card-body
 
   div
 
-    div(data-hook="new-particle-btns-" + this.viewIndex)
+    div.inline(data-hook="new-particle-btns-" + this.viewIndex)
 
       button.btn.btn-outline-primary.box-shadow(data-hook="add-particle") Add Particle
 
-    div(data-hook="edit-particle-btns-" + this.viewIndex)
+    div.inline(data-hook="edit-particle-btns-" + this.viewIndex)
 
       button.btn.btn-outline-primary.box-shadow.ml-2(data-hook="save-particle") Save Particle
 
       button.btn.btn-outline-primary.box-shadow.ml-2(data-hook="remove-particle") Remove Particle
+
+    div.mdl-edit-btn.saving-status.inline(data-hook="ep-in-progress")
+
+      div.spinner-grow.mr-2
+
+      span(data-hook="ep-action-in-progress")
+
+    div.mdl-edit-btn.saved-status.inline(data-hook="ep-complete")
+
+      span(data-hook="ep-action-complete")

--- a/client/templates/includes/editWorkflowView.pug
+++ b/client/templates/includes/editWorkflowView.pug
@@ -26,7 +26,7 @@ div
 
         div: h5="Notes: "
 
-        div: button.btn.btn-outline-collapse(data-toggle="collapse" data-target="#annotation-text"+this.model.name.replace(/ /g,"") data-hook="collapse-annotation-text") -
+        div: button.btn.btn-outline-collapse(data-toggle="collapse" data-target="#annotation-text"+this.model.name.replace(/ /g,"") data-hook="collapse-annotation-text") +
 
     div.collapse.col-md-11.inline(id="annotation-text"+this.model.name.replace(/ /g,""))
 

--- a/client/templates/includes/quickviewDomainTypes.pug
+++ b/client/templates/includes/quickviewDomainTypes.pug
@@ -1,0 +1,5 @@
+tr
+  
+  td=this.model.name
+
+  td=this.model.numParticles

--- a/client/templates/includes/spatialSpeciesEditor.pug
+++ b/client/templates/includes/spatialSpeciesEditor.pug
@@ -7,6 +7,9 @@ div#species-editor.card.card-body
 
   div.collapse(class="show", id="collapse-species")
 
+    p
+     | Time varying quantities of interest; e.g.: concentrations, populations, or counts of biochemical species, epidemological compartments, chemicals, proteins, or molecules.
+
     table.table
       thead
         tr

--- a/client/templates/pages/domainEditor.pug
+++ b/client/templates/pages/domainEditor.pug
@@ -196,9 +196,23 @@ section.page
 
               div.inline(id="types-file-location-select" data-hook="types-file-location-select")
 
-          div
+          div.inline
 
             button.btn.btn-outline-primary.box-shadow(data-hook="set-particle-types-btn" disabled) Set Types
+
+          div.mdl-edit-btn.saving-status.inline(data-hook="st-in-progress")
+
+            div.spinner-grow.mr-2
+
+            span(data-hook="st-action-in-progress")
+
+          div.mdl-edit-btn.saved-status.inline(data-hook="st-complete")
+
+            span(data-hook="st-action-complete")
+
+          div.mdl-edit-btn.save-error-status(data-hook="st-error")
+
+            span(data-hook="st-action-error")
 
         div.tab-pane(id="import-particles")
 
@@ -249,9 +263,23 @@ section.page
                   td: div(data-hook="mesh-y-trans")
                   td: div(data-hook="mesh-z-trans")
 
-          div
+          div.inline
 
             button.btn.btn-outline-primary.box-shadow(data-hook="import-particles-btn" disabled) Import Mesh
+
+          div.mdl-edit-btn.saving-status.inline(data-hook="im-in-progress")
+
+            div.spinner-grow.mr-2
+
+            span(data-hook="im-action-in-progress")
+
+          div.mdl-edit-btn.saved-status.inline(data-hook="im-complete")
+
+            span(data-hook="im-action-complete")
+
+          div.mdl-edit-btn.save-error-status(data-hook="im-error")
+
+            span(data-hook="im-action-error")
 
   div.card.card-body
 
@@ -265,7 +293,7 @@ section.page
 
       div(id="domain-plot" data-hook="domain-plot" style="height: 800px")
 
-  div
+  div.inline
 
     button.btn.btn-primary.box-shadow.dropdown-toggle(
       id="dave-domain",
@@ -278,3 +306,17 @@ section.page
     ul.dropdown-menu(aria-labelledby="save-domain")
       li.dropdown-item(data-hook="save-to-model") to Model
       li.dropdown-item(data-hook="save-to-file") to File (.domn)
+
+  div.mdl-edit-btn.saving-status.inline(data-hook="sd-in-progress")
+
+    div.spinner-grow.mr-2
+
+    span(data-hook="sd-action-in-progress")
+
+  div.mdl-edit-btn.saved-status.inline(data-hook="sd-complete")
+
+    span(data-hook="sd-action-complete")
+
+  div.mdl-edit-btn.save-error-status(data-hook="sd-error")
+
+    span(data-hook="sd-action-error")

--- a/client/templates/pages/domainEditor.pug
+++ b/client/templates/pages/domainEditor.pug
@@ -125,7 +125,7 @@ section.page
             tr
               th(scope="col") Mass
               th(scope="col") Volume
-              th(scope="col") Nu
+              th(scope="col") Viscosity
               th(scope="col") Fixed
 
           tbody
@@ -137,18 +137,6 @@ section.page
 
         button.btn.btn-outline-primary.box-shadow(data-hook="set-type-defaults") Submit
   
-  div.card.card-body
-
-    div
-
-      h3.inline Domain
-    
-      button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#domain-plot", data-hook="collapse-domain-plot") -
-
-    div.collapse.show(id="domain-plot" data-hook="domain-plot-container")
-
-      div(id="domain-plot" data-hook="domain-plot" style="height: 800px")
-
   div.card.card-body
 
     div
@@ -237,7 +225,7 @@ section.page
                 tr
                   th(scope="col") Mass
                   th(scope="col") Volume
-                  th(scope="col") Nu
+                  th(scope="col") Viscosity
                   th(scope="col") Fixed
 
               tbody
@@ -264,6 +252,18 @@ section.page
           div
 
             button.btn.btn-outline-primary.box-shadow(data-hook="import-particles-btn" disabled) Import Mesh
+
+  div.card.card-body
+
+    div
+
+      h3.inline Domain
+    
+      button.btn.btn-outline-collapse(data-toggle="collapse", data-target="#domain-plot", data-hook="collapse-domain-plot") -
+
+    div.collapse.show(id="domain-plot" data-hook="domain-plot-container")
+
+      div(id="domain-plot" data-hook="domain-plot" style="height: 800px")
 
   div
 

--- a/client/templates/pages/domainEditor.pug
+++ b/client/templates/pages/domainEditor.pug
@@ -147,7 +147,7 @@ section.page
 
     div.collapse.show(id="domain-plot" data-hook="domain-plot-container")
 
-      div(data-hook="domain-plot" style="height: 800px")
+      div(id="domain-plot" data-hook="domain-plot" style="height: 800px")
 
   div.card.card-body
 

--- a/client/templates/pages/modelEditor.pug
+++ b/client/templates/pages/modelEditor.pug
@@ -83,7 +83,7 @@ section.page
 
           div(data-hook="domain-plot-container")
 
-        div.col-sm-4
+        div.col-sm-4.overflow-auto(style="max-height:450px;")
 
           div.mt-2.particle-view(data-hook="me-particle-viewer")
 
@@ -117,7 +117,7 @@ section.page
 
     div
 
-      div.inline(data-hook="preview-domain-buttons")
+      div.mt-1.inline(data-hook="preview-domain-buttons")
 
         button.btn.btn-outline-secondary.box-shadow.mx-2(data-hook="toggle-preview-domain" style="display: none") Hide Domain
 

--- a/client/templates/pages/modelEditor.pug
+++ b/client/templates/pages/modelEditor.pug
@@ -79,16 +79,25 @@ section.page
 
       div.row
 
-        div.col-sm-9
+        div.col-sm-8
 
           div(data-hook="domain-plot-container")
 
-        div.col-sm-3
+        div.col-sm-4
 
-          div.mt-2(data-hook="me-particle-viewer")
+          div.mt-2.particle-view(data-hook="me-particle-viewer")
 
-          div.text-info(data-hook="me-select-particle")
-            | Click on a particle to view its properties.
+          div.mt-2.particle-view(data-hook="me-select-particle")
+
+            div.text-info
+              | Click on a particle to view its properties.
+
+            div.mt-2
+
+              h4 Particles per Type
+
+              table.table
+                tbody(data-hook="me-types-quick-view")
 
     div(data-hook="model-run-container")
 

--- a/client/templates/pages/modelEditor.pug
+++ b/client/templates/pages/modelEditor.pug
@@ -36,7 +36,7 @@ section.page
 
   div(data-hook="reactions-editor-container")
 
-  div.card.card-body
+  div.card.card-body(data-hook="model-editor-advanced-container")
 
     div
 

--- a/client/templates/pages/modelEditor.pug
+++ b/client/templates/pages/modelEditor.pug
@@ -73,6 +73,23 @@ section.page
 
   div(class="preview-nav")
 
+    div(data-hook="domain-plot-viewer-container" style="display: none")
+
+      div: h4 Domain and Particle Preview
+
+      div.row
+
+        div.col-sm-9
+
+          div(data-hook="domain-plot-container")
+
+        div.col-sm-3
+
+          div.mt-2(data-hook="me-particle-viewer")
+
+          div.text-info(data-hook="me-select-particle")
+            | Click on a particle to view its properties.
+
     div(data-hook="model-run-container")
 
       div(data-hook="preview-plot-container")
@@ -91,8 +108,12 @@ section.page
 
     div
 
-      div.mt-1.preview-buttons(data-hook="preview-plot-buttons")
-      
+      div.inline(data-hook="preview-domain-buttons")
+
+        button.btn.btn-outline-secondary.box-shadow.mx-2(data-hook="toggle-preview-domain" style="display: none") Hide Domain
+
+      div.mt-1.preview-buttons.inline(data-hook="preview-plot-buttons")
+
         button.btn.btn-outline-secondary.box-shadow.inline.mx-2(data-hook="toggle-preview-plot") Hide Preview
 
         button.btn.btn-outline-secondary.box-shadow.inline.dropdown-toggle(

--- a/client/templates/pages/workflowSelection.pug
+++ b/client/templates/pages/workflowSelection.pug
@@ -39,14 +39,14 @@ section.page
       tr
         td: button.btn.btn-outline-primary.box-shadow(id="ensemble-simulation" data-hook="ensemble-simulation" data-type="gillespy")
               | Ensemble Simulation
+        td: button.btn.btn-outline-primary.box-shadow(id="spatial-simulation" data-hook="spatial-simulation" data-type="spatial")
+              | Spatial Ensemble Simulation
         td: button.btn.btn-outline-primary.box-shadow(id="oned-parameter-sweep" data-hook="oned-parameter-sweep" data-type="1d_parameter_sweep")
               | 1D Parameter Sweep
+      tr
         td: button.btn.btn-outline-primary.box-shadow(id="twod-parameter-sweep" data-hook="twod-parameter-sweep" data-type="2d_parameter_sweep")
               | 2D Parameter Sweep
-      tr
         td: button.btn.btn-outline-primary.box-shadow(id="sciope-model-exploration" data-hook="sciope-model-exploration" data-type="sciope_model_exploration")
               | Sciope Model Exploration
         td: button.btn.btn-outline-primary.box-shadow(id="model-inference" data-hook="model-inference" data-type="model_inference")
               | Sciope Model Inference
-        td: div
-

--- a/client/views/domain-viewer.js
+++ b/client/views/domain-viewer.js
@@ -193,11 +193,15 @@ module.exports = View.extend({
     var el = this.queryByHook("domain-plot");
     Plotly.newPlot(el, this.plot);
     el.on('plotly_click', _.bind(this.selectParticle, this));
+    var domainPreview = this.parent.queryByHook("domain-plot-container");
+    Plotly.newPlot(domainPreview, this.plot);
+    domainPreview.on('plotly_click', _.bind(this.selectParticle, this));
   },
   selectParticle: function (data) {
     let point = data.points[0];
     let particle = this.model.particles.get(point.id, "particle_id");
     this.renderParticleViewer(particle);
+    this.parent.renderParticleViewer(particle);
   },
   editDomain: function (e) {
     var queryStr = "?path=" + this.parent.model.directory;

--- a/client/views/domain-viewer.js
+++ b/client/views/domain-viewer.js
@@ -69,7 +69,7 @@ module.exports = View.extend({
   },
   reloadDomain: function (domainPath) {
     if(this.domainPath !== domainPath || domainPath === "viewing") {
-      var el = this.queryByHook("domain-plot");
+      var el = this.parent.queryByHook("domain-plot-container");
       el.removeListener('plotly_click', this.selectParticle);
       Plotly.purge(el);
       this.plot = null;
@@ -111,6 +111,7 @@ module.exports = View.extend({
         queryStr += "&domain_path=" + this.domainPath
       }
     }
+    this.parent.renderParticleViewer(null);
     let endpoint = path.join(app.getApiPath(), "spatial-model/domain-plot") + queryStr;
     xhr({uri: endpoint, json: true}, function (err, resp, body) {
       self.plot = body.fig;
@@ -163,18 +164,6 @@ module.exports = View.extend({
     });
     this.registerRenderSubview(this.domainLocationSelectView, "select-location")
   },
-  renderParticleViewer: function (particle=null) {
-    if(this.particleViewer) {
-      this.particleViewer.remove();
-    }
-    if(particle){
-      $(this.queryByHook("select-particle")).css("display", "none")
-      this.particleViewer = new ParticleViewer({
-        model: particle
-      });
-      this.registerRenderSubview(this.particleViewer, "particle-viewer")
-    }
-  },
   renderTypesViewer: function () {
     if(this.typesViewer) {
       this.typesViewer.remove()
@@ -190,9 +179,6 @@ module.exports = View.extend({
   },
   displayDomain: function () {
     let self = this;
-    var el = this.queryByHook("domain-plot");
-    Plotly.newPlot(el, this.plot);
-    el.on('plotly_click', _.bind(this.selectParticle, this));
     var domainPreview = this.parent.queryByHook("domain-plot-container");
     Plotly.newPlot(domainPreview, this.plot);
     domainPreview.on('plotly_click', _.bind(this.selectParticle, this));
@@ -200,7 +186,6 @@ module.exports = View.extend({
   selectParticle: function (data) {
     let point = data.points[0];
     let particle = this.model.particles.get(point.id, "particle_id");
-    this.renderParticleViewer(particle);
     this.parent.renderParticleViewer(particle);
   },
   editDomain: function (e) {

--- a/client/views/edit-3D-domain.js
+++ b/client/views/edit-3D-domain.js
@@ -70,6 +70,9 @@ module.exports = View.extend({
           self.parent.domain.z_lim[1] = body.limits.z_lim[1]
         }
         self.parent.renderDomainLimitations();
+        $('html, body').animate({
+            scrollTop: $("#domain-plot").offset().top
+        }, 20);
       }
     });
   },

--- a/client/views/edit-3D-domain.js
+++ b/client/views/edit-3D-domain.js
@@ -51,6 +51,25 @@ module.exports = View.extend({
     xhr({uri: endpoint, json: true, method: "post", body: this.data}, function (err, resp, body) {
       if(resp.statusCode < 400) {
         self.parent.addParticles(body.particles);
+        if(self.parent.domain.x_lim[0] > body.limits.x_lim[0]) {
+          self.parent.domain.x_lim[0] = body.limits.x_lim[0]
+        }
+        if(self.parent.domain.y_lim[0] > body.limits.y_lim[0]) {
+          self.parent.domain.y_lim[0] = body.limits.y_lim[0]
+        }
+        if(self.parent.domain.z_lim[0] > body.limits.z_lim[0]) {
+          self.parent.domain.z_lim[0] = body.limits.z_lim[0]
+        }
+        if(self.parent.domain.x_lim[1] < body.limits.x_lim[1]) {
+          self.parent.domain.x_lim[1] = body.limits.x_lim[1]
+        }
+        if(self.parent.domain.y_lim[1] < body.limits.y_lim[1]) {
+          self.parent.domain.y_lim[1] = body.limits.y_lim[1]
+        }
+        if(self.parent.domain.z_lim[1] < body.limits.z_lim[1]) {
+          self.parent.domain.z_lim[1] = body.limits.z_lim[1]
+        }
+        self.parent.renderDomainLimitations();
       }
     });
   },

--- a/client/views/edit-3D-domain.js
+++ b/client/views/edit-3D-domain.js
@@ -38,6 +38,7 @@ module.exports = View.extend({
     'click [data-hook=build-domain]' : 'handleBuildDomain'
   },
   handleBuildDomain: function (e) {
+    this.startAction("Creating domain ...")
     this.data.type = {"type_id":this.type.typeID, "mass":this.type.mass, "nu":this.type.nu, "fixed":this.type.fixed};
     this.data.volume = this.type.volume;
     let xtrans = Number($(this.queryByHook("domain-x-trans")).find('input')[0].value);
@@ -70,9 +71,12 @@ module.exports = View.extend({
           self.parent.domain.z_lim[1] = body.limits.z_lim[1]
         }
         self.parent.renderDomainLimitations();
+        self.completeAction("Domain successfully created")
         $('html, body').animate({
             scrollTop: $("#domain-plot").offset().top
         }, 20);
+      }else{
+        self.errorAction(body.Message)
       }
     });
   },
@@ -107,6 +111,22 @@ module.exports = View.extend({
     this.renderType();
     this.renderTypeDefaults();
     this.renderDomainTransformations();
+  },
+  completeAction: function (action) {
+    $(this.queryByHook("cd-in-progress")).css("display", "none");
+    $(this.queryByHook("cd-action-complete")).text(action);
+    $(this.queryByHook("cd-complete")).css("display", "inline-block");
+    console.log(action)
+    let self = this
+    setTimeout(function () {
+      $(self.queryByHook("cd-complete")).css("display", "none");
+    }, 5000);
+  },
+  errorAction: function (action) {
+    $(this.queryByHook("cd-in-progress")).css("display", "none");
+    $(this.queryByHook("cd-action-error")).text(action);
+    $(this.queryByHook("cd-error")).css("display", "block");
+    console.log(action)
   },
   renderDomainTransformations: function () {
     let xtrans = new InputView({parent: this, required: true,
@@ -183,6 +203,12 @@ module.exports = View.extend({
     $(this.queryByHook("volume")).text(this.type.volume)
     $(this.queryByHook("nu")).text(this.type.nu)
     $(this.queryByHook("fixed")).prop("checked", this.type.fixed)
+  },
+  startAction: function (action) {
+    $(this.queryByHook("cd-complete")).css("display", "none");
+    $(this.queryByHook("cd-action-in-progress")).text(action);
+    $(this.queryByHook("cd-in-progress")).css("display", "inline-block");
+    console.log(action)
   },
   update: function (e) {},
   updateTotalParticles: function (e) {

--- a/client/views/edit-model-view.js
+++ b/client/views/edit-model-view.js
@@ -51,9 +51,6 @@ module.exports = View.extend({
     }else{
       $(this.queryByHook('collapse-annotation-container'+this.model.name.replace(/ /g,""))).collapse('show')
     }
-    if(this.model.is_spatial) {
-      $(this.queryByHook("new-workflow-btn")).prop("disabled", true);
-    }
   },
   handleEditModelClick: function (e) {
     let queryString = "?path="+this.model.directory

--- a/client/views/edit-particle.js
+++ b/client/views/edit-particle.js
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 var $ = require('jquery');
+var _ = require('underscore');
 //support files
 var tests = require('../views/tests');
 //views
@@ -40,10 +41,16 @@ module.exports = View.extend({
     'click [data-hook=remove-particle]' : 'handleRemoveParticle'
   },
   handleAddParticle: function (e) {
-    this.parent.addParticle(this.model);
+    this.startAction("Adding particle ...")
+    this.parent.addParticle(this.model, {cb: _.bind(function () {
+      this.completeAction("Particle Added")
+    }, this)});
   },
   handleSaveParticle: function (e) {
-    this.parent.updateParticle();
+    this.startAction("Saving particle ...")
+    this.parent.updateParticle({cb: _.bind(function () {
+      this.completeAction("Particle Saved")
+    }, this)});
   },
   handleRemoveParticle: function (e) {
     this.parent.deleteParticle();
@@ -100,6 +107,16 @@ module.exports = View.extend({
     View.prototype.initialize.apply(this, arguments);
     this.newParticle = attrs.newParticle;
     this.viewIndex = this.newParticle ? 0 : 1;
+  },
+  completeAction: function (action) {
+    $(this.queryByHook("ep-in-progress")).css("display", "none");
+    $(this.queryByHook("ep-action-complete")).text(action);
+    $(this.queryByHook("ep-complete")).css("display", "inline-block");
+    console.log(action)
+    let self = this
+    setTimeout(function () {
+      $(self.queryByHook("ep-complete")).css("display", "none");
+    }, 5000);
   },
   disableAll: function () {
     $(this.queryByHook("x-coord-" + this.viewIndex)).find('input').prop('disabled', true);
@@ -184,6 +201,12 @@ module.exports = View.extend({
       value: this.parent.domain.types.get(this.model.type, "typeID")
     });
     this.registerRenderSubview(typeView, "type-" + this.viewIndex)
+  },
+  startAction: function (action) {
+    $(this.queryByHook("ep-complete")).css("display", "none");
+    $(this.queryByHook("ep-action-in-progress")).text(action);
+    $(this.queryByHook("ep-in-progress")).css("display", "inline-block");
+    console.log(action)
   },
   update: function (e) {},
   updateValid: function (e) {}

--- a/client/views/edit-workflows-view.js
+++ b/client/views/edit-workflows-view.js
@@ -66,12 +66,7 @@ module.exports = View.extend({
     return error
   },
   handleNewWorkflowClick: function (e) {
-    let models = this.parent.parent.parent.model.models.filter(function (model) {
-      return !model.is_spatial
-    });
-    let spatial = this.parent.parent.parent.model.models.filter(function (model) {
-      return model.is_spatial
-    });
+    let models = this.parent.parent.parent.model.models
     if(models.length > 0) {
       let self = this
       if(document.querySelector("#newProjectWorkflowModal")) {
@@ -82,7 +77,9 @@ module.exports = View.extend({
       let okBtn = document.querySelector("#newProjectWorkflowModal .ok-model-btn")
       let select = document.querySelector("#newProjectWorkflowModal #select")
       okBtn.addEventListener('click', function (e) {
-        let mdlFile = select.value.endsWith('.mdl') ? select.value : select.value + ".mdl"
+        let mdlFile = models.filter(function (model) {
+          return model.name === select.value;
+        })[0].directory.split("/").pop();
         let mdlPath =  path.join(self.parent.parent.parent.projectPath, mdlFile)
         let parentPath = path.join(self.parent.parent.parent.projectPath, self.parent.model.name)+".wkgp"
         let queryString = "?path="+mdlPath+"&parentPath="+parentPath
@@ -90,10 +87,6 @@ module.exports = View.extend({
         modal.modal('hide')
         window.location.href = endpoint
       });
-    }else if(spatial.length > 0) {
-      let title = "Workflow Not Available"
-      let message = "Workflows for spatial models are not currently available."
-      let modal = $(modals.noModelsMessageHtml(title, message)).modal()
     }else{
       let title = "No Models Found"
       let message = "You need to add a model before you can create a new workflow."

--- a/client/views/file-browser-view.js
+++ b/client/views/file-browser-view.js
@@ -190,7 +190,7 @@ module.exports = View.extend({
   updateParent: function (type, trash = false) {
     if(trash){
       this.parent.update("all")
-    }else if(type === "nonspatial" || type === "workflow" || type === "workflow-group") {
+    }else if(type === "nonspatial" || type === "spatial" || type === "workflow" || type === "workflow-group") {
       this.parent.update("file-browser")
     }
   },

--- a/client/views/file-browser-view.js
+++ b/client/views/file-browser-view.js
@@ -336,7 +336,7 @@ module.exports = View.extend({
         }else{
           self.refreshJSTree();
         }
-        if(resp.file.endsWith(".mdl") || resp.file.endsWith(".sbml")) {
+        if(resp.file.endsWith(".mdl") || resp.file.endsWith(".smdl") ||resp.file.endsWith(".sbml")) {
           self.parent.update("file-browser")
         }
         if(resp.errors.length > 0){

--- a/client/views/file-browser-view.js
+++ b/client/views/file-browser-view.js
@@ -188,9 +188,10 @@ module.exports = View.extend({
     });
   },
   updateParent: function (type, trash = false) {
+    let types = ["nonspatial", "spatial", "workflow", "workflow-group", "notebook"]
     if(trash){
       this.parent.update("all")
-    }else if(type === "nonspatial" || type === "spatial" || type === "workflow" || type === "workflow-group") {
+    }else if(types.includes(type)) {
       this.parent.update("file-browser")
     }
   },
@@ -492,6 +493,9 @@ module.exports = View.extend({
             var msg = body.message
             var errors = body.errors
             let modal = $(modals.sbmlToModelHtml(msg, errors)).modal();
+          }else{
+            console.log(node.type, o.type)
+            self.updateParent(o.type)
           }
         }
       }
@@ -769,8 +773,12 @@ module.exports = View.extend({
       let okBtn = document.querySelector('#newProjectWorkflowModal .ok-model-btn')
       let select = document.querySelector('#newProjectWorkflowModal #select')
       okBtn.addEventListener("click", function (e) {
+          modal.modal('hide')
+          let mdlFile = o.type === "workflow-group" ? self.parent.model.models.filter(function (model) {
+            return model.name === select.value;
+          })[0].directory.split("/").pop() : null;
           let parentPath = o.type === "workflow-group" ? o.original._path : path.join(path.dirname(o.original._path), select.value + ".wkgp")
-          let modelPath = o.type === "workflow-group" ? path.join(path.dirname(o.original._path), select.value + ".mdl") : o.original._path
+          let modelPath = o.type === "workflow-group" ? path.join(path.dirname(o.original._path), mdlFile) : o.original._path
           let endpoint = path.join(app.getBasePath(), "stochss/workflow/selection")+"?path="+modelPath+"&parentPath="+parentPath
           window.location.href = endpoint
       });
@@ -1137,7 +1145,7 @@ module.exports = View.extend({
       let newWorkflow = {
         "NewWorkflow" : {
           "label" : "New Workflow",
-          "_disabled" : (nodeType === "spatial") ? true : false,
+          "_disabled" : false,
           "separator_before" : false,
           "separator_after" : true,
           "action" : function (data) {
@@ -1206,20 +1214,12 @@ module.exports = View.extend({
           "separator_after" : true,
           "submenu" : {
             "Convert to Model" : {
-              "label" : "Convert to Non Spatial",
+              "label" : "Convert to Model",
               "_disabled" : false,
               "separator_before" : false,
               "separator_after" : false,
               "action" : function (data) {
                 self.toModel(o, "Spatial");
-              }
-            },
-            "Convert to Notebook" : {
-              "label" : "Convert to Notebook",
-              "_disabled" : true,
-              "separator_before" : false,
-              "separator_after" : false,
-              "action" : function (data) {
               }
             }
           }

--- a/client/views/model-state-buttons.js
+++ b/client/views/model-state-buttons.js
@@ -49,7 +49,6 @@ module.exports = View.extend({
     if(this.model.is_spatial) {
       $(this.queryByHook("stochss-es")).addClass("disabled");
       $(this.queryByHook("stochss-ps")).addClass("disabled");
-      $(this.queryByHook("new-workflow")).addClass("disabled");
     }
   },
   clickSaveHandler: function (e) {
@@ -263,13 +262,13 @@ module.exports = View.extend({
       let simType = e.target.dataset.type
       if(simType === "preview") {
         this.clickRunHandler(e)
+      }else if(simType === "notebook"){
+        this.clickNewWorkflowHandler(e)
       }else if(!this.model.is_spatial) {
         if(simType === "ensemble") {
           this.handleEnsembleSimulationClick(e)
         }else if(simType === "psweep") {
           this.handleParameterSweepClick(e)
-        }else{
-          this.clickNewWorkflowHandler(e)
         }
       }
     }

--- a/client/views/model-state-buttons.js
+++ b/client/views/model-state-buttons.js
@@ -56,6 +56,9 @@ module.exports = View.extend({
     this.saveModel(this.saved.bind(this));
   },
   clickRunHandler: function (e) {
+    if(this.model.is_spatial && $(this.queryByHook("domain-plot-viewer-container")).css("display") !== "none") {
+      this.parent.closeDomainPlot()
+    }
     $(this.parent.queryByHook('model-run-error-container')).collapse('hide');
     $(this.parent.queryByHook('model-timeout-message')).collapse('hide');
     var el = this.parent.queryByHook('preview-plot-container');
@@ -154,7 +157,7 @@ module.exports = View.extend({
       this.saved();
     }
     this.running();
-    var el = this.parent.queryByHook('model-run-container')
+    $(this.parent.queryByHook('model-run-container')).css("display", "block")
     var model = this.model
     var queryStr = "?cmd=start&outfile=none&path="+model.directory
     if(species) {

--- a/client/views/model-state-buttons.js
+++ b/client/views/model-state-buttons.js
@@ -179,7 +179,7 @@ module.exports = View.extend({
           body = JSON.parse(body)
         }
         var data = body.Results;
-        if(response.statusCode >= 400){
+        if(response.statusCode >= 400 || data.errors){
           self.ran(false);
           $(self.parent.queryByHook('model-run-error-message')).text(data.errors);
         }

--- a/client/views/model-state-buttons.js
+++ b/client/views/model-state-buttons.js
@@ -152,6 +152,10 @@ module.exports = View.extend({
     errors.style.display = "none";
   },
   ran: function (noErrors) {
+    var runContainer = $(this.parent.queryByHook("model-run-container"));
+    if(runContainer.css("display") === "none") {
+      runContainer.css("display", 'block');
+    }
     $(this.parent.queryByHook('preview-plot-buttons')).css('display', 'inline-block')
     let plotBtn = $(this.parent.queryByHook('toggle-preview-plot'))
     if(plotBtn.text() === "Show Preview") {

--- a/client/views/quickview-domain-types.js
+++ b/client/views/quickview-domain-types.js
@@ -1,0 +1,26 @@
+/*
+StochSS is a platform for simulating biochemical systems
+Copyright (C) 2019-2020 StochSS developers.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//views
+var View = require('ampersand-view');
+//templates
+var template = require('../templates/includes/quickviewDomainTypes.pug');
+
+module.exports = View.extend({
+  template: template,
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ gillespy2==1.5.7
 sciope==0.4
 pygmsh==5.0.2
 meshio==2.3.10
-git+https://github.com/spatialpy/SpatialPy.git@develop
+git+https://github.com/spatialpy/SpatialPy.git@main

--- a/stochss/handlers/file_browser.py
+++ b/stochss/handlers/file_browser.py
@@ -83,11 +83,12 @@ class ModelToNotebookHandler(APIHandler):
         log.debug("Path to the model file: %s", path)
         self.set_header('Content-Type', 'application/json')
         try:
-            model = StochSSModel(path=path)
+            is_spatial = path.endswith(".smdl")
+            model = StochSSSpatialModel(path=path) if is_spatial else StochSSModel(path=path)
             data = model.get_notebook_data()
             log.debug("Notebook data: %s", data)
             notebook = StochSSNotebook(**data)
-            resp = notebook.create_es_notebook()
+            resp = notebook.create_ses_notebook() if is_spatial else notebook.create_es_notebook()
             log.debug("Notebook file path: %s", resp)
             self.write(resp)
         except StochSSAPIError as err:

--- a/stochss/handlers/models.py
+++ b/stochss/handlers/models.py
@@ -196,10 +196,13 @@ class RunModelAPIHandler(APIHandler):
         if outfile == 'none':
             outfile = str(uuid.uuid4()).replace("-", "_")
         log.debug("Temporary outfile: %s", outfile)
+        species = self.get_query_argument(name="species", default=None)
         resp = {"Running":False, "Outfile":outfile, "Results":""}
         if run_cmd == "start":
             exec_cmd = ['/stochss/stochss/handlers/util/scripts/run_preview.py',
                         f'{path}', f'{outfile}']
+            if species is not None:
+                exec_cmd.append(f"{species}")
             log.debug("Script commands for running a preview: %s", exec_cmd)
             subprocess.Popen(exec_cmd)
             resp['Running'] = True

--- a/stochss/handlers/util/parameter_sweep.py
+++ b/stochss/handlers/util/parameter_sweep.py
@@ -104,7 +104,7 @@ class ParameterSweep(StochSSWorkflow):
             wkfl.get_plotly_layout_data(plt_data=plt_data)
             layout = plotly.graph_objs.Layout(title=dict(text=plt_data['title'], x=0.5),
                                               xaxis=dict(title=plt_data['xaxis_label']),
-                                              yaxis=dict(title=plt_data['xaxis_label']))
+                                              yaxis=dict(title=plt_data['yaxis_label']))
 
             fig = dict(data=trace_list, layout=layout, config={"responsive": True})
             plot_figs['-'.join(key)] = fig

--- a/stochss/handlers/util/parameter_sweep_2d.py
+++ b/stochss/handlers/util/parameter_sweep_2d.py
@@ -112,7 +112,7 @@ class ParameterSweep2D():
             Existing layout data
         '''
         if "yaxis_label" not in plt_data:
-            plt_data['xaxis_label'] = f"<b>{self.params[1]['parameter']}</b>"
+            plt_data['yaxis_label'] = f"<b>{self.params[1]['parameter']}</b>"
         if "xaxis_label" not in plt_data:
             plt_data['xaxis_label'] = f"<b>{self.params[0]['parameter']}</b>"
 

--- a/stochss/handlers/util/scripts/run_preview.py
+++ b/stochss/handlers/util/scripts/run_preview.py
@@ -63,6 +63,7 @@ def get_parsed_args():
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('path', help="The path from the user directory to the model.")
     parser.add_argument('outfile', help="The temp file used to hold the results.")
+    parser.add_argument('species', help="Spatial species to preview.", default=None)
     return parser.parse_args()
 
 
@@ -93,7 +94,7 @@ if __name__ == "__main__":
     is_spatial = args.path.endswith(".smdl")
     if is_spatial:
         model = StochSSSpatialModel(path=args.path)
-        wkfl = SpatialSimulation(path="", preview=True)
+        wkfl = SpatialSimulation(path="", preview=True, species=args.species)
         wkfl.s_py_model = model.convert_to_spatialpy()
     else:
         log_stm = setup_logger()

--- a/stochss/handlers/util/spatial_simulation.py
+++ b/stochss/handlers/util/spatial_simulation.py
@@ -30,7 +30,7 @@ class SpatialSimulation(StochSSWorkflow):
 
     TYPE = "spatial"
 
-    def __init__(self, path, preview=False):
+    def __init__(self, path, preview=False, species=None):
         '''
         Intitialize a spatial ensemble simulation workflow object
 
@@ -43,6 +43,8 @@ class SpatialSimulation(StochSSWorkflow):
         if not preview:
             self.settings = self.load_settings()
             self.s_py_model, self.s_model = self.load_models()
+        else:
+            self.species = species
 
 
     def __get_run_settings(self):
@@ -65,9 +67,10 @@ class SpatialSimulation(StochSSWorkflow):
             if verbose:
                 self.log("info", "Running a preview spatial ensemble simulation")
             results = self.s_py_model.run(timeout=60)
-            species = list(self.s_py_model.get_all_species().keys())[0]
+            # if self.species is None:
+            #     self.species = list(self.s_py_model.get_all_species().keys())[0]
             t_ndx_list = list(range(len(os.listdir(results.result_dir)) - 1))
-            plot = results.plot_species(species=species, t_ndx_list=t_ndx_list, animated=True,
+            plot = results.plot_species(species=self.species, t_ndx_list=t_ndx_list, animated=True,
                                         width=None, height=None, return_plotly_figure=True,
                                         f_duration=100, t_duration=100)
             plot["layout"]["autosize"] = True

--- a/stochss/handlers/util/stochss_folder.py
+++ b/stochss/handlers/util/stochss_folder.py
@@ -104,10 +104,10 @@ class StochSSFolder(StochSSBase):
 
 
     def __upload_model(self, file, body, new_name=None):
-        is_spatial = '"is_spatial":true' in body
         is_valid, error = self.__validate_model(body, file)
         if is_valid:
-            ext = "mdl" if is_spatial else "smdl"
+            is_spatial = json.loads(body)['is_spatial']
+            ext = "smdl" if is_spatial else "mdl"
         else:
             ext = "json"
         if new_name is not None:

--- a/stochss/handlers/util/stochss_model.py
+++ b/stochss/handlers/util/stochss_model.py
@@ -396,7 +396,7 @@ class StochSSModel(StochSSBase):
         file = f"{self.get_name()}.ipynb"
         path = os.path.join(self.get_dir_name(), file)
         g_model = self.convert_to_gillespy2()
-        return {"path":path, "new":True, "models":{"s_model":self.model, "g_model":g_model}}
+        return {"path":path, "new":True, "models":{"s_model":self.model, "model":g_model}}
 
 
     def get_preview_results(self, outfile):

--- a/stochss/handlers/util/stochss_notebook.py
+++ b/stochss/handlers/util/stochss_notebook.py
@@ -25,7 +25,7 @@ from nbformat import v4 as nbf
 from gillespy2.solvers.utilities.cpp_support_test import check_cpp_support
 
 from .stochss_base import StochSSBase
-from .stochss_errors import StochSSAPIError, StochSSFileNotFoundError, StochSSModelFormatError
+from .stochss_errors import StochSSFileNotFoundError, StochSSModelFormatError
 
 class StochSSNotebook(StochSSBase):
     '''
@@ -33,15 +33,15 @@ class StochSSNotebook(StochSSBase):
     StochSS notebook object
     ################################################################################################
     '''
-
     ENSEMBLE_SIMULATION = 1
-    PARAMETER_SWEEP_1D = 2
-    PARAMETER_SWEEP_2D = 3
-    MODEL_EXPLORATION = 4
-    MODEL_INFERENCE = 5
+    SPATIAL_SIMULATION = 2
+    PARAMETER_SWEEP_1D = 3
+    PARAMETER_SWEEP_2D = 4
+    MODEL_EXPLORATION = 5
+    MODEL_INFERENCE = 6
     SOLVER_MAP = {"SSACSolver":"SSA", "NumPySSASolver":"SSA", "VariableSSACSolver":"V-SSA",
                   "TauLeapingSolver":"Tau-Leaping", "TauHybridSolver":"Hybrid-Tau-Leaping",
-                  "ODESolver":"ODE"}
+                  "ODESolver":"ODE", "Solver":"SSA"}
 
     def __init__(self, path, new=False, models=None, settings=None):
         '''
@@ -57,7 +57,7 @@ class StochSSNotebook(StochSSBase):
             self.is_ssa_c = check_cpp_support()
             self.nb_type = 0
             self.s_model = models["s_model"]
-            self.g_model = models["g_model"]
+            self.model = models["model"]
             self.settings = self.get_settings_template() if settings is None else settings
             self.make_parent_dirs()
             n_path, changed = self.get_unique_path(name=self.get_file())
@@ -74,7 +74,6 @@ class StochSSNotebook(StochSSBase):
                  self.__create_configuration_cell()]
         return cells
 
-
     def __create_configuration_cell(self):
         pad = "    "
         config = ["def configure_simulation():"]
@@ -86,7 +85,10 @@ class StochSSNotebook(StochSSBase):
             start = f"{pad}# " if commented else pad
             config.append(f"{start}solver = {self.settings['solver']}(model=model)")
         config.append(pad + "kwargs = {")
-        settings = self.__get_gillespy2_run_settings()
+        if self.s_model['is_spatial']:
+            settings = self.__get_spatialpy_run_setting()
+        else:
+            settings = self.__get_gillespy2_run_settings()
         settings_lists = {"ODE":['"solver"', '"integrator_options"'],
                           "SSA":['"solver"', '"seed"', '"number_of_trajectories"'],
                           "V-SSA":['"solver"', '"seed"', '"number_of_trajectories"'],
@@ -95,13 +97,14 @@ class StochSSNotebook(StochSSBase):
                           "Hybrid-Tau-Leaping":['"solver"', '"seed"', '"number_of_trajectories"',
                                                 '"tau_tol"', '"integrator_options"']}
         algorithm = self.settings['simulationSettings']['algorithm']
+        is_spatial = self.s_model['is_spatial']
         for setting in settings:
             key = setting.split(':')[0]
             if self.settings['solver'] == "VariableSSACSolver" and key == '"solver"':
                 start = pad*2
             elif key not in settings_lists[algorithm]:
                 start = f"{pad*2}# "
-            elif is_automatic and key == '"number_of_trajectories"':
+            elif is_automatic and not is_spatial and key == '"number_of_trajectories"':
                 start = pad*2
             elif is_automatic:
                 start = f"{pad*2}# "
@@ -110,7 +113,6 @@ class StochSSNotebook(StochSSBase):
             config.append(f"{start}{setting},")
         config.extend([pad + "}", f"{pad}return kwargs"])
         return nbf.new_code_cell("\n".join(config))
-
 
     def __create_event_strings(self, model, pad):
         if self.s_model['eventsCollection']:
@@ -137,7 +139,6 @@ class StochSSNotebook(StochSSBase):
                 message += f"are referenced incorrectly for notebooks: {str(err)}"
                 raise StochSSModelFormatError(message, traceback.format_exc())
 
-
     @classmethod
     def __create_event_assignment_strings(cls, assignments, event, pad):
         names = []
@@ -149,7 +150,6 @@ class StochSSNotebook(StochSSBase):
             assignments.append(assign_str)
         return ', '.join(names)
 
-
     @classmethod
     def __create_event_trigger_string(cls, triggers, event, pad):
         name = f'{event["name"]}_trig'
@@ -157,7 +157,6 @@ class StochSSNotebook(StochSSBase):
         trig_str += f'initial_value={event["initialValue"]}, persistent={event["persistent"]})'
         triggers.append(trig_str)
         return name
-
 
     def __create_function_definition_strings(self, model, pad):
         if self.s_model['functionDefinitions']:
@@ -174,14 +173,21 @@ class StochSSNotebook(StochSSBase):
                 message += f"are referenced incorrectly for notebooks: {str(err)}"
                 raise StochSSModelFormatError(message, traceback.format_exc())
 
-
     def __create_import_cell(self, interactive_backend=False):
         try:
-            imports = ["import numpy as np"]
+            is_automatic = self.settings['simulationSettings']['isAutomatic']
+            if self.nb_type == self.SPATIAL_SIMULATION:
+                imports = ["%load_ext autoreload", "%autoreload 2", "", "import numpy as np"]
+            else:
+                imports = ["import numpy as np"]
             if interactive_backend:
                 imports.append("%matplotlib notebook")
             if self.s_model['is_spatial']:
-                imports.append("import spatialPy")
+                imports.append("import spatialpy")
+                imports.append("from spatialpy import Model, Species, Parameter, Reaction, Mesh,\\")
+                imports.append("                      PlaceInitialCondition, \\")
+                imports.append("                      UniformInitialCondition, \\")
+                imports.append("                      ScatterInitialCondition")
                 return nbf.new_code_cell("\n".join(imports))
             imports.append("import gillespy2")
             imports.append("from gillespy2 import Model, Species, Parameter, Reaction, Event, \\")
@@ -193,7 +199,6 @@ class StochSSNotebook(StochSSBase):
                              'Tau-Leaping': 'from gillespy2 import TauLeapingSolver',
                              'Hybrid-Tau-Leaping': 'from gillespy2 import TauHybridSolver',
                              'ODE': 'from gillespy2 import ODESolver'}
-            is_automatic = self.settings['simulationSettings']['isAutomatic']
             algorithm = self.settings['simulationSettings']['algorithm']
             if self.nb_type > self.ENSEMBLE_SIMULATION and algorithm == "SSA":
                 algorithm = "V-SSA"
@@ -210,41 +215,81 @@ class StochSSNotebook(StochSSBase):
             message += f"are referenced incorrectly for notebooks: {str(err)}"
             raise StochSSModelFormatError(message, traceback.format_exc())
 
+    def __create_initial_condition_strings(self, model, pad):
+        if self.s_model['initialConditions']:
+            ic_types = {"Place":"PlaceInitialCondition", "Scatter":"ScatterInitialCondition",
+                        "Distribute Uniformly per Voxel":"UniformInitialCondition"}
+            initial_conditions = ["", f"{pad}# Initial Conditions"]
+            try:
+                for init_cond in self.s_model['initialConditions']:
+                    ic_str = f'{pad}self.add_initial_condition({ic_types[init_cond["icType"]]}('
+                    ic_str += f'species={init_cond["specie"]["name"]}, count={init_cond["count"]},'
+                    if init_cond["icType"] == "Place":
+                        place = f'{init_cond["x"]}, {init_cond["y"]}, {init_cond["z"]}'
+                        ic_str += f' location=[{place}]))'
+                    else:
+                        ic_str += f' types={str(init_cond["types"])}))'
+                    initial_conditions.append(ic_str)
+                model.extend(initial_conditions)
+            except KeyError as err:
+                message = "Initial conditions are not properly formatted or "
+                message += f"are referenced incorrectly for notebooks: {str(err)}"
+                raise StochSSModelFormatError(message, traceback.format_exc())
+
+    def __create_mesh_string(self, model, pad):
+        mesh = ["", f"{pad}# Domain",
+                f"{pad}mesh = Mesh.read_stochss_domain('{self.s_model['path']}')",
+                f"{pad}self.add_mesh(mesh)"]
+        model.extend(mesh)
 
     def __create_model_cell(self):
-        if self.s_model['is_spatial']:
-            reason = "Function Not Supported"
-            message = "Spatial not yet implemented."
-            raise StochSSAPIError(403, reason, message, traceback.format_exc())
         pad = '        '
-        model = [f"class {self.__get_class_name()}(Model):",
-                 "    def __init__(self, parameter_values=None):",
-                 f'{pad}Model.__init__(self, name="{self.get_name()}")',
-                 f"{pad}self.volume = {self.s_model['volume']}"]
-        self.__create_parameter_strings(model=model, pad=pad)
-        self.__create_species_strings(model=model, pad=pad)
-        self.__create_reaction_strings(model=model, pad=pad)
-        self.__create_event_strings(model=model, pad=pad)
-        self.__create_rules_strings(model=model, pad=pad)
-        self.__create_function_definition_strings(model=model, pad=pad)
-        self.__create_tspan_string(model=model, pad=pad)
+        if self.s_model['is_spatial']:
+            model = [f"class {self.__get_class_name()}(Model):",
+                     "    def __init__(self):",
+                     f'{pad}Model.__init__(self, name="{self.get_name()}")']
+            self.__create_mesh_string(model=model, pad=pad)
+            self.__create_species_strings(model=model, pad=pad)
+            self.__create_initial_condition_strings(model=model, pad=pad)
+            self.__create_parameter_strings(model=model, pad=pad)
+            self.__create_reaction_strings(model=model, pad=pad)
+            self.__create_tspan_string(model=model, pad=pad)
+        else:
+            model = [f"class {self.__get_class_name()}(Model):",
+                     "    def __init__(self, parameter_values=None):",
+                     f'{pad}Model.__init__(self, name="{self.get_name()}")',
+                     f"{pad}self.volume = {self.s_model['volume']}"]
+            self.__create_parameter_strings(model=model, pad=pad)
+            self.__create_species_strings(model=model, pad=pad)
+            self.__create_reaction_strings(model=model, pad=pad)
+            self.__create_event_strings(model=model, pad=pad)
+            self.__create_rules_strings(model=model, pad=pad)
+            self.__create_function_definition_strings(model=model, pad=pad)
+            self.__create_tspan_string(model=model, pad=pad)
         return nbf.new_code_cell("\n".join(model))
-
 
     def __create_parameter_strings(self, model, pad):
         if self.s_model['parameters']:
             parameters = ["", f"{pad}# Parameters"]
+            if self.s_model['is_spatial']:
+                names = []
             try:
                 for param in self.s_model['parameters']:
-                    param_str = f'{pad}self.add_parameter(Parameter(name="{param["name"]}", '
-                    param_str += f'expression="{param["expression"]}"))'
+                    if self.s_model['is_spatial']:
+                        names.append(param['name'])
+                        param_str = f'{pad}{param["name"]} = Parameter(name="{param["name"]}", '
+                        param_str += f'expression="{param["expression"]}")'
+                    else:
+                        param_str = f'{pad}self.add_parameter(Parameter(name="{param["name"]}", '
+                        param_str += f'expression="{param["expression"]}"))'
                     parameters.append(param_str)
                 model.extend(parameters)
+                if self.s_model['is_spatial']:
+                    model.append(f"{pad}self.add_parameter([{', '.join(names)}])")
             except KeyError as err:
                 message = "Parameters are not properly formatted or "
                 message += f"are referenced incorrectly for notebooks: {str(err)}"
                 raise StochSSModelFormatError(message, traceback.format_exc())
-
 
     def __create_ps_post_process_cells(self):
         pad = "    "
@@ -275,7 +320,6 @@ class StochSSNotebook(StochSSBase):
             cells.append(nbf.new_code_cell('\n'.join(aa_cell)))
         return cells
 
-
     def __create_ps1d_class_cell(self):
         pad = "    "
         run_str = self.__create_ps1d_run_str()
@@ -290,7 +334,6 @@ class StochSSNotebook(StochSSBase):
         class_cell = ["class ParameterSweep1D():", "", run_str, "", "",
                       "\n".join(plt_strs), "", "", pltly_str]
         return nbf.new_code_cell("\n".join(class_cell))
-
 
     def __create_ps1d_config_cell(self):
         pad = "    "
@@ -328,7 +371,6 @@ class StochSSNotebook(StochSSBase):
                             f"{pad}ensemble_aggragator = mean_std_of_ensemble"])
         return nbf.new_code_cell("\n".join(config_cell))
 
-
     @classmethod
     def __create_ps1d_plotly_str(cls):
         pad = "    "
@@ -349,7 +391,6 @@ class StochSSNotebook(StochSSBase):
                       f"{pad*2}if return_plotly_figure:",
                       f"{pad*3}return fig", f"{pad*2}iplot(fig)"]
         return "\n".join(pltly_strs)
-
 
     def __create_ps1d_run_str(self):
         pad = "    "
@@ -379,7 +420,6 @@ class StochSSNotebook(StochSSBase):
                          f"{pad*2}c.data = data"])
         return "\n".join(run_strs)
 
-
     def __create_ps2d_class_cell(self):
         pad = "    "
         run_str = self.__create_ps2d_run_str()
@@ -401,7 +441,6 @@ class StochSSNotebook(StochSSBase):
         class_cell = ["class ParameterSweep2D():", "", run_str, "", "",
                       "\n".join(plt_strs), "", "", pltly_str]
         return nbf.new_code_cell("\n".join(class_cell))
-
 
     def __create_ps2d_config_cell(self):
         pad = "    "
@@ -454,7 +493,6 @@ class StochSSNotebook(StochSSBase):
                             f"{pad}ensemble_aggragator = average_of_ensemble"])
         return nbf.new_code_cell("\n".join(config_cell))
 
-
     @classmethod
     def __create_ps2d_plotly_str(cls):
         pad = "    "
@@ -472,7 +510,6 @@ class StochSSNotebook(StochSSBase):
                       f"{pad*2}if return_plotly_figure:",
                       f"{pad*3}return fig", f"{pad*2}iplot(fig)"]
         return "\n".join(pltly_strs)
-
 
     def __create_ps2d_run_str(self):
         pad = "    "
@@ -502,27 +539,37 @@ class StochSSNotebook(StochSSBase):
                          f"{pad*2}c.data = data"])
         return "\n".join(run_strs)
 
-
     def __create_reaction_strings(self, model, pad):
         if self.s_model['reactions']:
             reactions = ["", f"{pad}# Reactions"]
+            if self.s_model['is_spatial']:
+                names = []
             try:
                 for reac in self.s_model['reactions']:
                     react_str = self.__create_stoich_spec_string(stoich_species=reac['reactants'])
                     prod_str = self.__create_stoich_spec_string(stoich_species=reac['products'])
-                    reac_str = f'{pad}self.add_reaction(Reaction(name="{reac["name"]}", '
+                    if self.s_model['is_spatial']:
+                        names.append(reac['name'])
+                        reac_str = f'{pad}{reac["name"]} = Reaction(name="{reac["name"]}", '
+                        if len(reac['types']) < len(self.s_model['domain']['types']) - 1:
+                            reac_str += f'restrict_to={str(reac["types"])}, '
+                    else:
+                        reac_str = f'{pad}self.add_reaction(Reaction(name="{reac["name"]}", '
                     reac_str += f'reactants={react_str}, products={prod_str}, '
                     if reac['reactionType'] == 'custom-propensity':
-                        reac_str += f'propensity_function="{reac["propensity"]}"))'
+                        reac_str += f'propensity_function="{reac["propensity"]}")'
                     else:
-                        reac_str += f'rate=self.listOfParameters["{reac["rate"]["name"]}"]))'
+                        reac_str += f'rate=self.listOfParameters["{reac["rate"]["name"]}"])'
+                    if not self.s_model['is_spatial']:
+                        reac_str += ")"
                     reactions.append(reac_str)
                 model.extend(reactions)
+                if self.s_model['is_spatial']:
+                    model.append(f"{pad}self.add_reaction([{', '.join(names)}])")
             except KeyError as err:
                 message = "Reactions are not properly formatted or "
                 message += f"are referenced incorrectly for notebooks: {str(err)}"
                 raise StochSSModelFormatError(message, traceback.format_exc())
-
 
     def __create_rules_strings(self, model, pad):
         if self.s_model['rules']:
@@ -547,7 +594,6 @@ class StochSSNotebook(StochSSBase):
                 message = "Rules are not properly formatted or "
                 message += f"are referenced incorrectly for notebooks: {str(err)}"
                 raise StochSSModelFormatError(message, traceback.format_exc())
-
 
     @classmethod
     def __create_sme_expres_cells(cls):
@@ -583,9 +629,8 @@ class StochSSNotebook(StochSSBase):
                  nbf.new_code_cell("met.data.user_labels = user_labels")]
         return cells
 
-
     def __create_sme_setup_cells(self):
-        spec_of_interest = list(self.g_model.get_all_species().keys())
+        spec_of_interest = list(self.model.get_all_species().keys())
         # Wrapper cell
         sim_str = "simulator = wrapper.get_simulator(gillespy_model=model, "
         sim_str += f"run_settings=settings, species_of_interest={spec_of_interest})"
@@ -615,7 +660,6 @@ class StochSSNotebook(StochSSBase):
                  nbf.new_code_cell("\n".join(ism_strs))]
         return cells
 
-
     def __create_smi_setup_cells(self):
         pad = "    "
         priors = ["# take default from mode 1 as reference",
@@ -635,7 +679,6 @@ class StochSSNotebook(StochSSBase):
                  nbf.new_markdown_cell("## Define summary statistics and distance function"),
                  nbf.new_code_cell("\n".join(stat_dist))]
         return cells
-
 
     def __create_smi_simulator_cell(self):
         pad = "    "
@@ -667,24 +710,36 @@ class StochSSNotebook(StochSSBase):
         sim_strs.extend(simulator2)
         return nbf.new_code_cell("\n".join(sim_strs))
 
-
     def __create_species_strings(self, model, pad):
         if self.s_model['species']:
             species = ["", f"{pad}# Variables"]
+            if self.s_model['is_spatial']:
+                names = []
+                types_str = [""]
             try:
                 for spec in self.s_model['species']:
-                    spec_str = f'{pad}self.add_species(Species(name="{spec["name"]}", '
-                    spec_str += f'initial_value={spec["value"]}, mode="{spec["mode"]}"))'
+                    if self.s_model['is_spatial']:
+                        names.append(spec["name"])
+                        spec_str = f'{pad}{spec["name"]} = Species(name="{spec["name"]}", '
+                        spec_str += f"diffusion_constant={spec['diffusionConst']})"
+                        if len(spec['types']) < len(self.s_model['domain']['types']) - 1:
+                            type_str = f"{pad}self.restrict({spec['name']}, {str(spec['types'])})"
+                            types_str.append(type_str)
+                    else:
+                        spec_str = f'{pad}self.add_species(Species(name="{spec["name"]}", '
+                        spec_str += f'initial_value={spec["value"]}, mode="{spec["mode"]}"))'
                     species.append(spec_str)
                 model.extend(species)
+                if self.s_model['is_spatial']:
+                    model.append(f"{pad}self.add_species([{', '.join(names)}])")
+                    if len(types_str) > 1:
+                        model.extend(types_str)
             except KeyError as err:
                 message = "Species are not properly formatted or "
                 message += f"are referenced incorrectly for notebooks: {str(err)}"
                 raise StochSSModelFormatError(message, traceback.format_exc())
 
-
-    @classmethod
-    def __create_stoich_spec_string(cls, stoich_species):
+    def __create_stoich_spec_string(self, stoich_species):
         species = {}
         for stoich_spec in stoich_species:
             name = stoich_spec['specie']['name']
@@ -692,16 +747,24 @@ class StochSSNotebook(StochSSBase):
                 species[name] += stoich_spec['ratio']
             else:
                 species[name] = stoich_spec['ratio']
-        return str(species)
-
+        spec_list = []
+        for name, ratio in species.items():
+            if not self.s_model['is_spatial']:
+                name = f"'{name}'"
+            spec_list.append(f"{name}: {ratio}")
+        return "{" + ", ".join(spec_list) + "}"
 
     def __create_tspan_string(self, model, pad):
         end = self.s_model['modelSettings']['endSim']
         step = self.s_model['modelSettings']['timeStep']
-        tspan = ["", f"{pad}# Timespan",
-                 f'{pad}self.timespan(np.arange(0, {end}, {step}))']
+        tspan = ["", f"{pad}# Timespan"]
+        ts_str = f'{pad}self.timespan(np.arange(0, {end}, {step})'
+        if self.s_model['is_spatial']:
+            ts_str += f", timestep_size={step})"
+        else:
+            ts_str += ")"
+        tspan.append(ts_str)
         model.extend(tspan)
-
 
     def __get_class_name(self):
         name = self.get_name()
@@ -713,7 +776,6 @@ class StochSSNotebook(StochSSBase):
         if l_char in string.ascii_lowercase:
             return name.replace(l_char, l_char.upper(), 1)
         return name
-
 
     def __get_gillespy2_run_settings(self):
         is_automatic = self.settings['simulationSettings']['isAutomatic']
@@ -742,11 +804,17 @@ class StochSSNotebook(StochSSBase):
         run_settings.extend(algorithm_settings)
         return run_settings
 
+    def __get_spatialpy_run_setting(self):
+        self.settings['simulationSettings']['realizations'] = 1
+        settings = self.settings['simulationSettings']
+        settings_map = {"number_of_trajectories":settings['realizations'],
+                        "seed":settings['seed'] if settings['seed'] != -1 else None}
+        return [f'"{key}":{val}' for key, val in settings_map.items()]
 
     def __get_gillespy2_solver_name(self):
         precompile = self.nb_type > self.ENSEMBLE_SIMULATION
         if self.settings['simulationSettings']['isAutomatic']:
-            solver = self.g_model.get_best_solver(precompile=precompile).name
+            solver = self.model.get_best_solver(precompile=precompile).name
             self.settings['simulationSettings']['algorithm'] = self.SOLVER_MAP[solver]
             return solver
         algorithm_map = {'SSA': "SSACSolver" if self.is_ssa_c else "NumPySSASolver",
@@ -758,14 +826,11 @@ class StochSSNotebook(StochSSBase):
             return algorithm_map["V-SSA"]
         return algorithm_map[self.settings['simulationSettings']['algorithm']]
 
-
     def create_1dps_notebook(self):
-        '''
-        Create a 1D parameter sweep jupiter notebook for a StochSS model/workflow
+        '''Create a 1D parameter sweep jupiter notebook for a StochSS model/workflow
 
         Attributes
-        ----------
-        '''
+        ----------'''
         self.nb_type = self.PARAMETER_SWEEP_1D
         self.settings['solver'] = self.__get_gillespy2_solver_name()
         run_strs = ["kwargs = configure_simulation()", "ps = ParameterSweepConfig()",
@@ -783,14 +848,11 @@ class StochSSNotebook(StochSSBase):
         message = self.write_notebook_file(cells=cells)
         return {"Message":message, "FilePath":self.get_path(), "File":self.get_file()}
 
-
     def create_2dps_notebook(self):
-        '''
-        Create a 2D parameter sweep jupiter notebook for a StochSS model/workflow
+        '''Create a 2D parameter sweep jupiter notebook for a StochSS model/workflow
 
         Attributes
-        ----------
-        '''
+        ----------'''
         self.nb_type = self.PARAMETER_SWEEP_2D
         self.settings['solver'] = self.__get_gillespy2_solver_name()
         run_strs = ["kwargs = configure_simulation()", "ps = ParameterSweepConfig()",
@@ -808,14 +870,11 @@ class StochSSNotebook(StochSSBase):
         message = self.write_notebook_file(cells=cells)
         return {"Message":message, "FilePath":self.get_path(), "File":self.get_file()}
 
-
     def create_es_notebook(self):
-        '''
-        Create an ensemble simulation jupiter notebook for a StochSS model/workflow
+        '''Create an ensemble simulation jupiter notebook for a StochSS model/workflow
 
         Attributes
-        ----------
-        '''
+        ----------'''
         self.nb_type = self.ENSEMBLE_SIMULATION
         self.settings['solver'] = self.__get_gillespy2_solver_name()
         run_str = "kwargs = configure_simulation()\nresults = model.run(**kwargs)"
@@ -827,14 +886,29 @@ class StochSSNotebook(StochSSBase):
         message = self.write_notebook_file(cells=cells)
         return {"Message":message, "FilePath":self.get_path(), "File":self.get_file()}
 
-
-    def create_sme_notebook(self):
-        '''
-        Create a model exploration jupiter notebook for a StochSS model/workflow
+    def create_ses_notebook(self):
+        '''Create a spetial ensemble simulation jupiter notebook for a StochSS model/workflow
 
         Attributes
-        ----------
-        '''
+        ----------'''
+        self.nb_type = self.SPATIAL_SIMULATION
+        self.settings['solver'] = "Solver"
+        run_str = "kwargs = configure_simulation()\nresults = model.run(**kwargs)"
+        species = self.s_model['species'][0]['name']
+        plot_str = f"results.plot_species('{species}', animated=True, width=None, height=None)"
+        cells = self.__create_common_cells()
+        cells.extend([nbf.new_code_cell(run_str),
+                      nbf.new_markdown_cell("# Visualization"),
+                      nbf.new_code_cell(plot_str)])
+
+        message = self.write_notebook_file(cells=cells)
+        return {"Message":message, "FilePath":self.get_path(), "File":self.get_file()}
+
+    def create_sme_notebook(self):
+        '''Create a model exploration jupiter notebook for a StochSS model/workflow
+
+        Attributes
+        ----------'''
         self.nb_type = self.MODEL_EXPLORATION
         self.settings['solver'] = self.__get_gillespy2_solver_name()
         cells = self.__create_common_cells(interactive_backend=True)
@@ -847,14 +921,11 @@ class StochSSNotebook(StochSSBase):
         message = self.write_notebook_file(cells=cells)
         return {"Message":message, "FilePath":self.get_path(), "File":self.get_file()}
 
-
     def create_smi_notebook(self):
-        '''
-        Create a model inference jupiter notebook for a StochSS model/workflow
+        '''Create a model inference jupiter notebook for a StochSS model/workflow
 
         Attributes
-        ----------
-        '''
+        ----------'''
         self.nb_type = self.MODEL_INFERENCE
         self.settings['solver'] = self.__get_gillespy2_solver_name()
         cells = self.__create_common_cells()
@@ -894,14 +965,11 @@ class StochSSNotebook(StochSSBase):
         message = self.write_notebook_file(cells=cells)
         return {"Message":message, "FilePath":self.get_path(), "File":self.get_file()}
 
-
     def load(self):
-        '''
-        Read the notebook file and return as a dict
+        '''Read the notebook file and return as a dict
 
         Attributes
-        ----------
-        '''
+        ----------'''
         try:
             with open(self.get_path(full=True), "r") as notebook_file:
                 return json.load(notebook_file)
@@ -909,16 +977,13 @@ class StochSSNotebook(StochSSBase):
             message = f"Could not find the notebook file: {str(err)}"
             raise StochSSFileNotFoundError(message, traceback.format_exc())
 
-
     def write_notebook_file(self, cells):
-        '''
-        Write the new notebook file to disk
+        '''Write the new notebook file to disk
 
         Attributes
         ----------
         cells : list
-            List of cells for the new notebook
-        '''
+            List of cells for the new notebook'''
         path = self.get_path(full=True)
         notebook = nbf.new_notebook(cells=cells)
         with open(path, 'w') as file:

--- a/stochss/handlers/util/stochss_spatial_model.py
+++ b/stochss/handlers/util/stochss_spatial_model.py
@@ -429,8 +429,9 @@ class StochSSSpatialModel(StochSSBase):
             zlim = [coord + data['transformation'][2] for coord in data['zLim']]
         s_domain = Mesh.create_3D_domain(xlim=xlim, ylim=ylim, zlim=zlim, nx=data['nx'],
                                          ny=data['ny'], nz=data['nz'], **data['type'])
-        particles = cls.__build_stochss_domain_particles(s_domain=s_domain)
-        return {"particles":particles}
+        domain = cls.__build_stochss_domain(s_domain=s_domain)
+        limits = {"x_lim":domain['x_lim'], "y_lim":domain['y_lim'], "z_lim":domain['z_lim']}
+        return {"particles":domain['particles'], "limits":limits}
 
 
     @classmethod

--- a/stochss/handlers/util/stochss_spatial_model.py
+++ b/stochss/handlers/util/stochss_spatial_model.py
@@ -131,12 +131,9 @@ class StochSSSpatialModel(StochSSBase):
             gravity = self.model['domain']['gravity']
             if gravity == [0, 0, 0]:
                 gravity = None
-            type_ids = list(map(lambda d_type: d_type['typeID'], self.model['domain']['types']))
-            type_ids.pop(0)
-            model.listOfTypeIDs = type_ids
             mesh = Mesh(0, xlim, ylim, zlim, rho0=rho0, c0=c_0, P0=p_0, gravity=gravity)
             self.__convert_particles(mesh=mesh)
-            model.mesh = mesh
+            model.add_mesh(mesh)
         except KeyError as err:
             message = "Spatial model domain properties are not properly formatted or "
             message += f"are referenced incorrectly: {str(err)}"
@@ -172,8 +169,7 @@ class StochSSSpatialModel(StochSSBase):
             end = self.model['modelSettings']['endSim']
             step_size = self.model['modelSettings']['timeStep']
             tspan = numpy.arange(0, end, step_size)
-            model.timestep_size = step_size
-            model.timespan(tspan)
+            model.timespan(tspan, timestep_size=step_size)
         except KeyError as err:
             message = "Spatial model settings are not properly formatted or "
             message += f"are referenced incorrectly: {str(err)}"
@@ -342,12 +338,7 @@ class StochSSSpatialModel(StochSSBase):
         if self.model is None:
             _ = self.load()
         name = self.get_name()
-        # try:
         s_model = Model(name=name)
-        # except KeyError as err:
-        #     message = "Spatial model properties are not properly formatted or "
-        #     message += f"are referenced incorrectly: {str(err)}"
-        #     raise StochSSModelFormatError(message, traceback.format_exc())
         self.__convert_model_settings(model=s_model)
         self.__convert_domain(model=s_model)
         self.__convert_species(model=s_model)

--- a/stochss/handlers/util/stochss_spatial_model.py
+++ b/stochss/handlers/util/stochss_spatial_model.py
@@ -400,6 +400,20 @@ class StochSSSpatialModel(StochSSBase):
                           cls=plotly.utils.PlotlyJSONEncoder)
 
 
+    def get_notebook_data(self):
+        '''
+        Get the needed data for converting to notebook
+
+        Attributes
+        ----------
+        '''
+        file = f"{self.get_name()}.ipynb"
+        path = os.path.join(self.get_dir_name(), file)
+        s_model = self.convert_to_spatialpy()
+        self.model['path'] = self.get_file()
+        return {"path":path, "new":True, "models":{"s_model":self.model, "model":s_model}}
+
+
     @classmethod
     def get_particles_from_3d_domain(cls, data):
         '''

--- a/stochss/handlers/util/stochss_workflow.py
+++ b/stochss/handlers/util/stochss_workflow.py
@@ -281,7 +281,7 @@ class StochSSWorkflow(StochSSBase):
         else:
             wkfl_type = "2d_parameter_sweep"
         kwargs = {"path":path, "new":True, "settings":settings,
-                  "models":{"s_model":s_model, "g_model":g_model}}
+                  "models":{"s_model":s_model, "model":g_model}}
         return {"kwargs":kwargs, "type":wkfl_type}
 
 

--- a/stochss/handlers/workflows.py
+++ b/stochss/handlers/workflows.py
@@ -27,7 +27,7 @@ from notebook.base.handlers import APIHandler
 # Note APIHandler.finish() sets Content-Type handler to 'application/json'
 # Use finish() for json, write() for text
 
-from .util import StochSSWorkflow, StochSSModel, StochSSNotebook, \
+from .util import StochSSWorkflow, StochSSModel, StochSSSpatialModel, StochSSNotebook, \
                   StochSSAPIError, report_error
 
 log = logging.getLogger('stochss')
@@ -240,8 +240,12 @@ class WorkflowNotebookHandler(APIHandler):
         log.debug("Path to the model/workflow: %s", path)
         wkfl_type = self.get_query_argument(name="type")
         try:
-            is_model = path.endswith(".mdl")
-            file_obj = StochSSModel(path=path) if is_model else StochSSWorkflow(path=path)
+            if path.endswith(".mdl"):
+                file_obj = StochSSModel(path=path)
+            elif path.endswith(".smdl"):
+                file_obj = StochSSSpatialModel(path=path)
+            else:
+                file_obj = StochSSWorkflow(path=path)
             kwargs = file_obj.get_notebook_data()
             if "type" in kwargs.keys():
                 wkfl_type = kwargs['type']
@@ -249,6 +253,7 @@ class WorkflowNotebookHandler(APIHandler):
             log.debug("Type of workflow to be run: %s", wkfl_type)
             notebook = StochSSNotebook(**kwargs)
             notebooks = {"gillespy":notebook.create_es_notebook,
+                         "spatial":notebook.create_ses_notebook,
                          "1d_parameter_sweep":notebook.create_1dps_notebook,
                          "2d_parameter_sweep":notebook.create_2dps_notebook,
                          "sciope_model_exploration":notebook.create_sme_notebook,


### PR DESCRIPTION
## New Features
- Spatial species editor now has descriptive text preceding the list of species
- Domain limits are now automatically updated if a particle created using __Create 3D Domain__ is outside of the original limits
- Users are now taken back to the Model Editor page after they add a domain to their model in the Domain Editor
- Users cans now select species to preview when running a preview of a spatial model
- Users can now view the domain, type data, and particle data in a fixed section of the model editor
- Users are now taken to the domain section after creating a 3D domain or importing a mesh
- Spatial Ensemble Simulation notebooks are now available

## Bug Fixes
- Note button text now reflects the correct status of the container
- The type select list in the advanced section of the domain editor now update when a type is re-named
- Model preview errors are now show whenever errors are sent in the response dictionary
- Fixed model preview show/hide bug
- Volume and Advanced sections of the model editor are only displayed for Models
- Models are now uploaded with the proper extension (.mdl)
- 2D parameter sweep heat maps now show the correct axes labels
- Changes to spatial models now update the models section of the Project Manager